### PR TITLE
fix(ux): hide timer hero and reorder layout on mobile when no session

### DIFF
--- a/app/components/DashboardTimerHero.vue
+++ b/app/components/DashboardTimerHero.vue
@@ -252,6 +252,12 @@ function handleComplete(stint: StintRow) {
   }
 }
 
+@media (max-width: 767.98px) {
+  .session-card:not(.has-session) {
+    display: none;
+  }
+}
+
 /* Ambient glow effect */
 .ambient-glow {
   position: absolute;

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -179,8 +179,11 @@ async function handleConfirmComplete(notes: string) {
     <UContainer class="py-6 lg:py-8">
       <!-- 2-column grid layout -->
       <div class="flex flex-col lg:grid lg:grid-cols-[1fr_380px] gap-6 lg:gap-8 items-start">
-        <!-- Main Content: Projects (order-2 on mobile, order-1 on desktop) -->
-        <section class="order-2 lg:order-1 w-full space-y-6">
+        <!-- Main Content: Projects (order depends on active session on mobile, always first on desktop) -->
+        <section
+          class="w-full space-y-6 lg:order-1"
+          :class="activeStint ? 'order-2' : 'order-1'"
+        >
           <!-- Header -->
           <div class="flex items-center justify-between">
             <h2 class="text-xl lg:text-2xl font-semibold font-serif text-stone-900 dark:text-stone-50">
@@ -244,9 +247,10 @@ async function handleConfirmComplete(notes: string) {
           </UTabs>
         </section>
 
-        <!-- Sidebar (order-1 on mobile, order-2 on desktop) -->
+        <!-- Sidebar (order depends on active session on mobile, always second on desktop) -->
         <DashboardSidebar
-          class="order-1 lg:order-2 w-full"
+          class="w-full lg:order-2"
+          :class="activeStint ? 'order-1' : 'order-2'"
           :active-stint="activeStint ?? null"
           :active-project="activeProject"
           :daily-progress="dailyProgress"


### PR DESCRIPTION
## Summary

- Hide timer hero card on mobile (< 768px) when no active session to save screen space
- Reorder dashboard layout so Projects appear first when no session is active on mobile
- Desktop behavior remains unchanged

## Test plan

- [ ] Mobile, no session → Projects section appears first, timer card hidden
- [ ] Mobile, active session → Timer hero appears first, then Projects
- [ ] Desktop, no session → Empty state card visible in sidebar
- [ ] Desktop, active session → Timer visible in sidebar (no change)
- [ ] Start session on mobile → Layout reorders, timer appears at top
- [ ] End session on mobile → Layout reorders, projects move to top
- [ ] No layout shift or flash on page load

Closes #59