### PR TITLE
fix(cron): reduce auto-complete interval from 2 minutes to 1 minute

### DIFF
--- a/docs/04-technical-architecture.md
+++ b/docs/04-technical-architecture.md
@@ -266,7 +266,7 @@ sequenceDiagram
   - Validation handled via Zod schemas on client, database constraints on server
 
 - **Scheduled Tasks via pg_cron**
-  - `auto_complete_stints`: Auto-completes stints at planned end time (runs every 2 min)
+  - `auto_complete_stints`: Auto-completes stints at planned end time (runs every 1 min)
   - `aggregate_daily_stats`: Pre-calculates daily summaries (runs at midnight)
 
 - **CSV Export**
@@ -288,7 +288,7 @@ sequenceDiagram
 ### Scheduled Jobs
 
 - **pg_cron** (PostgreSQL extension)
-  - Auto-complete stints: `*/2 * * * *` (every 2 minutes)
+  - Auto-complete stints: `* * * * *` (every 1 minute)
   - Daily aggregation: `0 1 * * *` (1 AM UTC)
   - Cleanup old sessions: `0 2 * * *` (2 AM UTC)
   - Email digests: `0 8 * * 1` (8 AM UTC every Monday)

--- a/docs/05-database-schema.md
+++ b/docs/05-database-schema.md
@@ -426,10 +426,10 @@ CREATE EXTENSION IF NOT EXISTS pg_cron;
 Automatically completes stints that have exceeded their planned duration.
 
 ```sql
--- Runs every 2 minutes
+-- Runs every 1 minute (pg_cron minimum interval)
 SELECT cron.schedule(
   'auto-complete-stints',
-  '*/2 * * * *',
+  '* * * * *',
   $$SELECT auto_complete_expired_stints()$$
 );
 ```
@@ -621,7 +621,7 @@ INSERT INTO projects (user_id, name) VALUES ('other-user-uuid', 'Test');
 ### Auto-Completion Functions
 
 **auto_complete_expired_stints()**
-- Called by pg_cron every 2 minutes
+- Called by pg_cron every 1 minute
 - Finds all active stints past planned duration
 - Calls `complete_stint` for each expired stint
 - Returns: `completed_count`, `error_count`, `completed_stint_ids`

--- a/docs/06-implementation-guide.md
+++ b/docs/06-implementation-guide.md
@@ -325,7 +325,7 @@ self.onmessage = (e) => {
 
 ### Auto-Completion Fallback
 
-- pg_cron job runs every 2 minutes (`*/2 * * * *`)
+- pg_cron job runs every 1 minute (`* * * * *`)
 - Queries active stints where working time has reached planned duration:
   ```sql
   SELECT * FROM stints

--- a/supabase/migrations/20260126214631_update_auto_complete_cron_interval.sql
+++ b/supabase/migrations/20260126214631_update_auto_complete_cron_interval.sql
@@ -1,0 +1,46 @@
+-- Migration: Update auto-completion cron interval
+-- Date: 2026-01-26
+-- Description: Updates the pg_cron auto-complete job from every 2 minutes to every 1 minute.
+--              pg_cron supports a minimum interval of 1 minute, which reduces the maximum
+--              delay for auto-completing stints, improving user experience.
+--
+-- Related: Issue #26
+
+-- ============================================================================
+-- Update Auto-Completion Cron Schedule
+-- ============================================================================
+-- Change from */2 * * * * (every 2 minutes) to * * * * * (every 1 minute)
+
+DO $$
+BEGIN
+  -- Unschedule the existing job
+  IF EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'auto-complete-stints'
+  ) THEN
+    PERFORM cron.unschedule('auto-complete-stints');
+    RAISE NOTICE 'Unscheduled existing auto-complete-stints cron job';
+  END IF;
+
+  -- Reschedule with 1-minute interval
+  PERFORM cron.schedule(
+    'auto-complete-stints',
+    '* * * * *',  -- Every 1 minute (pg_cron minimum interval)
+    $job$ SELECT auto_complete_expired_stints(); $job$
+  );
+
+  RAISE NOTICE 'Scheduled auto-complete-stints cron job (now runs every 1 minute)';
+END $$;
+
+-- ============================================================================
+-- Verification Query
+-- ============================================================================
+-- To verify the cron job schedule was updated, run:
+--
+-- SELECT jobid, jobname, schedule, active
+-- FROM cron.job
+-- WHERE jobname = 'auto-complete-stints';
+--
+-- Expected output:
+-- jobid | jobname              | schedule  | active
+-- ------+----------------------+-----------+--------
+--     X | auto-complete-stints | * * * * * | t


### PR DESCRIPTION
## Summary
- Updates pg_cron auto-complete job from `*/2 * * * *` (every 2 minutes) to `* * * * *` (every 1 minute)
- Syncs documentation to reflect the 1-minute interval (which was already stated in feature requirements)

## Test plan
- [x] Migration applies cleanly (`supabase db reset`)
- [x] Cron job schedule verified via `cron.job` table query
- [x] All 384 tests pass
- [x] Lint and typecheck pass

Closes #26