### PR TITLE
refactor(speckit): enhance workflow with handoffs, AskUserQuestion, and subagent patterns

### DIFF
--- a/.claude/commands/speckit.checklist.md
+++ b/.claude/commands/speckit.checklist.md
@@ -35,9 +35,10 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
    - All file paths must be absolute.
+   - Use parallel Read calls in a single message.
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. **Clarify intent (dynamic)**: Derive up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
+2. **Clarify intent (dynamic)**: Use the AskUserQuestion tool to present up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
    - Be generated from the user's phrasing + extracted signals from spec/plan/tasks
    - Only ask about information that materially changes checklist content
    - Be skipped individually if already unambiguous in `$ARGUMENTS`
@@ -75,7 +76,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Map focus selections to category scaffolding
    - Infer any missing context from spec/plan/tasks (do NOT hallucinate)
 
-4. **Load feature context**: Read from FEATURE_DIR:
+4. **Load feature context**: Read from FEATURE_DIR (using parallel Read calls in a single message):
    - spec.md: Feature requirements and scope
    - plan.md (if exists): Technical details, dependencies
    - tasks.md (if exists): Implementation tasks

--- a/.claude/commands/speckit.clarify.md
+++ b/.claude/commands/speckit.clarify.md
@@ -1,5 +1,9 @@
 ---
-description: Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec.
+description: Identify underspecified areas in the current feature spec by asking up to 8 highly targeted clarification questions (in batches of up to 4) and encoding answers back into the spec.
+handoffs: 
+  - label: Build Technical Plan
+    agent: speckit.plan
+    prompt: Create a plan for the spec. I am building with...
 ---
 
 ## User Input
@@ -31,6 +35,8 @@ Execution steps:
    - Core user goals & success criteria
    - Explicit out-of-scope declarations
    - User roles / personas differentiation
+   - Requirement clarity (can two developers read this and build the same thing?)
+   - Ambiguous adjectives quantified ("robust", "intuitive", "fast" → concrete metrics)
 
    Domain & Data Model:
    - Entities, attributes, relationships
@@ -64,91 +70,76 @@ Execution steps:
    Constraints & Tradeoffs:
    - Technical constraints (language, storage, hosting)
    - Explicit tradeoffs or rejected alternatives
+   - Design rationale documented (why this approach over alternatives?)
+   - MVP scope clarity (what's the simplest version that delivers value?)
+   - Hidden assumptions surfaced (dependencies, preconditions, implicit contracts)
+
+   Architecture Alignment:
+   - Compatibility with existing codebase patterns and conventions
+   - Reuse of existing components vs. new abstractions
+   - Fit within current system boundaries and responsibilities
 
    Terminology & Consistency:
    - Canonical glossary terms
    - Avoided synonyms / deprecated terms
+   - Cross-reference accuracy (references to other specs/systems/docs align)
+   - Internal consistency (no conflicting requirements within spec)
 
    Completion Signals:
    - Acceptance criteria testability
    - Measurable Definition of Done style indicators
+   - Observable behavior (features verifiable without internal implementation knowledge)
 
    Misc / Placeholders:
    - TODO markers / unresolved decisions
-   - Ambiguous adjectives ("robust", "intuitive") lacking quantification
 
    For each category with Partial or Missing status, add a candidate question opportunity unless:
    - Clarification would not materially change implementation or validation strategy
    - Information is better deferred to planning phase (note internally)
 
-3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
-    - Maximum of 10 total questions across the whole session.
+3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 8). Apply these constraints:
+    - Maximum of 8 total questions across the whole session.
     - Each question must be answerable with EITHER:
-       - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
+       - A short multiple‑choice selection (2–4 distinct, mutually exclusive options), OR
        - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
     - Only include questions whose answers materially impact architecture, data modeling, task decomposition, test design, UX behavior, operational readiness, or compliance validation.
     - Ensure category coverage balance: attempt to cover the highest impact unresolved categories first; avoid asking two low-impact questions when a single high-impact area (e.g., security posture) is unresolved.
     - Exclude questions already answered, trivial stylistic preferences, or plan-level execution details (unless blocking correctness).
     - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
-    - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
+    - If more than 8 categories remain unresolved, select the top 8 by (Impact * Uncertainty) heuristic.
 
-4. Sequential questioning loop (interactive):
-    - Present EXACTLY ONE question at a time.
-    - For multiple‑choice questions:
-       - **Analyze all options** and determine the **most suitable option** based on:
-          - Best practices for the project type
-          - Common patterns in similar implementations
-          - Risk reduction (security, performance, maintainability)
-          - Alignment with any explicit project goals or constraints visible in the spec
-       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
-       - Format as: `**Recommended:** Option [X] - <reasoning>`
-       - Then render all options as a Markdown table:
-
-       | Option | Description |
-       |--------|-------------|
-       | A | <Option A description> |
-       | B | <Option B description> |
-       | C | <Option C description> (add D/E as needed up to 5) |
-       | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
-
-       - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
-    - For short‑answer style (no meaningful discrete options):
-       - Provide your **suggested answer** based on best practices and context.
-       - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
-       - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
-    - After the user answers:
-       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
-       - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
-       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
-       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
-    - Stop asking further questions when:
-       - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
-       - User signals completion ("done", "good", "no more"), OR
-       - You reach 5 asked questions.
-    - Never reveal future queued questions in advance.
+4. Batched questioning loop (interactive) - use the **AskUserQuestion tool**:
+    - Present UP TO 4 questions at a time in a single call. Group by relatedness where possible.
+    - For each question:
+       - Analyze options and put the **recommended option FIRST** with "(Recommended)" suffix.
+       - Use short `header` labels (max 12 chars): "Scope", "Data Model", "Error Flow", etc.
+       - Set `multiSelect: false` (clarifications should be single-choice).
+    - For short‑answer style (no discrete options): provide your suggested answer as option 1 with "(Suggested)" suffix; option 2 prompts user to select "Other".
+    - After user answers: if any answer is ambiguous, ask follow-up for just that question (counts toward quota). Once satisfactory, record in working memory and proceed to next batch.
+    - Stop when: all critical ambiguities resolved, user signals completion ("done", "proceed"), or 8 questions reached.
     - If no valid questions exist at start, immediately report no critical ambiguities.
 
-5. Integration after EACH accepted answer (incremental update approach):
+5. Integration after EACH batch of accepted answers (incremental update approach):
     - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
     - For the first integrated answer in this session:
        - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
        - Under it, create (if not present) a `### Session YYYY-MM-DD` subheading for today.
-    - Append a bullet line immediately after acceptance: `- Q: <question> → A: <final answer>`.
-    - Then immediately apply the clarification to the most appropriate section(s):
+    - For EACH answer in the batch, append a bullet line: `- Q: <question> → A: <final answer>`.
+    - Then immediately apply each clarification to the most appropriate section(s):
        - Functional ambiguity → Update or add a bullet in Functional Requirements.
        - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
        - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
        - Non-functional constraint → Add/modify measurable criteria in Non-Functional / Quality Attributes section (convert vague adjective to metric or explicit target).
        - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
        - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
-    - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
-    - Save the spec file AFTER each integration to minimize risk of context loss (atomic overwrite).
+    - If any clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
+    - Save the spec file AFTER integrating all answers from the batch to minimize risk of context loss (atomic overwrite).
     - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
     - Keep each inserted clarification minimal and testable (avoid narrative drift).
 
-6. Validation (performed after EACH write plus final pass):
+6. Validation (performed after EACH batch write plus final pass):
    - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
-   - Total asked (accepted) questions ≤ 5.
+   - Total asked (accepted) questions ≤ 8.
    - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
    - No contradictory earlier statement remains (scan for now-invalid alternative choices removed).
    - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
@@ -168,7 +159,7 @@ Behavior rules:
 
 - If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
 - If spec file missing, instruct user to run `/speckit.specify` first (do not create a new spec here).
-- Never exceed 5 total asked questions (clarification retries for a single question do not count as new questions).
+- Never exceed 8 total asked questions (clarification retries for a single question do not count as new questions).
 - Avoid speculative tech stack questions unless the absence blocks functional clarity.
 - Respect user early termination signals ("stop", "done", "proceed").
 - If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.

--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -12,123 +12,370 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
-1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+### Step 1: Prerequisites Check
 
-2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
-   - Scan all checklist files in the checklists/ directory
-   - For each checklist, count:
-     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
-     - Completed items: Lines matching `- [X]` or `- [x]`
-     - Incomplete items: Lines matching `- [ ]`
-   - Create a status table:
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-     ```text
-     | Checklist | Total | Completed | Incomplete | Status |
-     |-----------|-------|-----------|------------|--------|
-     | ux.md     | 12    | 12        | 0          | ✓ PASS |
-     | test.md   | 8     | 5         | 3          | ✗ FAIL |
-     | security.md | 6   | 6         | 0          | ✓ PASS |
-     ```
+---
 
-   - Calculate overall status:
-     - **PASS**: All checklists have 0 incomplete items
-     - **FAIL**: One or more checklists have incomplete items
+### Step 2: Check Checklists (if FEATURE_DIR/checklists/ exists)
 
-   - **If any checklist is incomplete**:
-     - Display the table with incomplete item counts
-     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
-     - Wait for user response before continuing
-     - If user says "no" or "wait" or "stop", halt execution
-     - If user says "yes" or "proceed" or "continue", proceed to step 3
+**Delegate to Explore agent** for checklist scanning:
 
-   - **If all checklists are complete**:
-     - Display the table showing all checklists passed
-     - Automatically proceed to step 3
+Launch an Explore agent with this prompt:
+```
+Scan all checklist files in {FEATURE_DIR}/checklists/. For each file:
+- Count total items (lines matching `- [ ]` or `- [X]` or `- [x]`)
+- Count completed items (lines matching `- [X]` or `- [x]`)
+- Count incomplete items (lines matching `- [ ]`)
 
-3. Load and analyze the implementation context:
-   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
-   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
-   - **IF EXISTS**: Read data-model.md for entities and relationships
-   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
-   - **IF EXISTS**: Read research.md for technical decisions and constraints
-   - **IF EXISTS**: Read quickstart.md for integration scenarios
+Return a JSON summary in this exact format:
+{
+  "checklists": [
+    { "filename": "ux.md", "total": 12, "completed": 12, "incomplete": 0 },
+    { "filename": "test.md", "total": 8, "completed": 5, "incomplete": 3 }
+  ],
+  "allComplete": false
+}
+```
 
-4. **Project Setup Verification**:
-   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+**Process agent results**:
+- Parse the JSON summary from the agent
+- Create a status table from the condensed data:
 
-   **Detection & Creation Logic**:
-   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+  ```text
+  | Checklist | Total | Completed | Incomplete | Status |
+  |-----------|-------|-----------|------------|--------|
+  | ux.md     | 12    | 12        | 0          | ✓ PASS |
+  | test.md   | 8     | 5         | 3          | ✗ FAIL |
+  ```
 
-     ```sh
-     git rev-parse --git-dir 2>/dev/null
-     ```
+- **If any checklist is incomplete** (`allComplete: false`):
+  - Display the table with incomplete item counts
+  - **STOP** Use the AskUserQuestion tool and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+  - Wait for user response before continuing
+  - If user says "no" or "wait" or "stop", halt execution
+  - If user says "yes" or "proceed" or "continue", proceed to step 3
 
-   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
-   - Check if .eslintrc*or eslint.config.* exists → create/verify .eslintignore
-   - Check if .prettierrc* exists → create/verify .prettierignore
-   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
-   - Check if terraform files (*.tf) exist → create/verify .terraformignore
-   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+- **If all checklists are complete** (`allComplete: true`):
+  - Display the table showing all checklists passed
+  - Automatically proceed to step 3
 
-   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
-   **If ignore file missing**: Create with full pattern set for detected technology
+---
 
-   **Common Patterns by Technology** (from plan.md tech stack):
-   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
-   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
-   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
-   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
-   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
-   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
-   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
-   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
-   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
-   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
-   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `Makefile`, `config.log`, `.idea/`, `*.log`, `.env*`
-   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
-   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
-   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+### Step 3: Load Implementation Context
 
-   **Tool-Specific Patterns**:
-   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
-   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
-   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
-   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
-   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+**Delegate to Explore agent** for spec summarization:
 
-5. Parse tasks.md structure and extract:
-   - **Task phases**: Setup, Tests, Core, Integration, Polish
-   - **Task dependencies**: Sequential vs parallel execution rules
-   - **Task details**: ID, description, file paths, parallel markers [P]
-   - **Execution flow**: Order and dependency requirements
+Launch an Explore agent with this prompt:
+```
+Read and summarize the following files from {FEATURE_DIR}:
 
-6. Execute implementation following the task plan:
-   - **Phase-by-phase execution**: Complete each phase before moving to the next
-   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
-   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
-   - **File-based coordination**: Tasks affecting the same files must run sequentially
-   - **Validation checkpoints**: Verify each phase completion before proceeding
+**REQUIRED FILES:**
+- tasks.md: Extract ALL task phases, task IDs, descriptions, [P] parallel markers, and file paths
+- plan.md: Extract tech stack, architecture decisions, file structure, critical constraints
 
-7. Implementation execution rules:
-   - **Setup first**: Initialize project structure, dependencies, configuration
-   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
-   - **Core development**: Implement models, services, CLI commands, endpoints
-   - **Integration work**: Database connections, middleware, logging, external services
-   - **Polish and validation**: Unit tests, performance optimization, documentation
+**OPTIONAL FILES (if they exist):**
+- data-model.md: Extract entities, relationships, and field definitions
+- contracts/: Extract API specifications and test requirements
+- research.md: Extract key technical decisions and constraints
+- quickstart.md: Extract integration scenarios
 
-8. Progress tracking and error handling:
-   - Report progress after each completed task
-   - Halt execution if any non-parallel task fails
-   - For parallel tasks [P], continue with successful tasks, report failed ones
-   - Provide clear error messages with context for debugging
-   - Suggest next steps if implementation cannot proceed
-   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+Return a structured JSON summary:
+{
+  "techStack": {
+    "language": "TypeScript",
+    "framework": "Phaser 3",
+    "buildTool": "Vite",
+    "otherTech": ["arcade physics", "..."]
+  },
+  "architecture": {
+    "patterns": ["Entity-Component", "Event-driven"],
+    "fileStructure": { "src/entities": "game entities", "src/systems": "game systems" },
+    "keyConstraints": ["No external dependencies", "Must use existing event system"]
+  },
+  "tasks": {
+    "phases": ["Setup", "Tests", "Core", "Integration", "Polish"],
+    "items": [
+      {
+        "id": "1.1",
+        "phase": "Setup",
+        "description": "Create health component",
+        "files": ["src/components/Health.ts"],
+        "isParallel": false,
+        "dependsOn": []
+      }
+    ]
+  },
+  "dataModel": {
+    "entities": [{ "name": "Enemy", "fields": ["health", "maxHealth"] }]
+  },
+  "contracts": {
+    "apis": [],
+    "testRequirements": []
+  },
+  "criticalConstraints": [
+    "Must maintain 60 FPS",
+    "No breaking changes to existing systems"
+  ]
+}
+```
 
-9. Completion validation:
-   - Verify all required tasks are completed
-   - Check that implemented features match the original specification
-   - Validate that tests pass and coverage meets requirements
-   - Confirm the implementation follows the technical plan
-   - Report final status with summary of completed work
+**Store the structured digest** for use in subsequent steps. Main agent now has condensed context, not full file contents.
 
-Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.
+---
+
+### Step 4: Project Setup Verification
+
+**Main agent handles directly** (minimal context, straightforward file operations):
+
+- **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+**Detection & Creation Logic**:
+- Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+  ```sh
+  git rev-parse --git-dir 2>/dev/null
+  ```
+
+- Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+- Check if .eslintrc* exists → create/verify .eslintignore
+- Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+- Check if .prettierrc* exists → create/verify .prettierignore
+- Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+- Check if terraform files (*.tf) exist → create/verify .terraformignore
+- Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+**If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+**If ignore file missing**: Create with full pattern set for detected technology
+
+**Common Patterns by Technology** (from techStack in digest):
+- **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+- **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+- **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+- **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+- **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+- **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+- **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+- **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+- **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+- **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+- **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `Makefile`, `config.log`, `.idea/`, `*.log`, `.env*`
+- **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+- **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+- **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+**Tool-Specific Patterns**:
+- **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+- **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+- **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+- **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+- **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+---
+
+### Step 5: Parse Task Structure
+
+**Delegate to Plan agent** for execution DAG:
+
+Launch a Plan agent with this prompt:
+```
+Given this task summary from the spec digest:
+{tasks_from_step_3}
+
+Build an execution plan:
+1. Identify task phases: Setup, Tests, Core, Integration, Polish
+2. Parse dependencies: sequential vs parallel [P] tasks
+3. Group tasks that can run concurrently (tasks marked [P] with no file conflicts)
+4. Identify file conflicts (tasks touching same files must be sequential)
+5. Determine TDD ordering (test tasks before their corresponding implementation)
+
+Return an ordered execution plan:
+{
+  "executionGroups": [
+    {
+      "groupId": 1,
+      "phase": "Setup",
+      "canParallelize": false,
+      "tasks": [
+        { "id": "1.1", "description": "...", "files": [...], "isParallel": false }
+      ],
+      "blockedBy": []
+    },
+    {
+      "groupId": 2,
+      "phase": "Tests",
+      "canParallelize": true,
+      "tasks": [
+        { "id": "2.1", "description": "...", "files": [...], "isParallel": true },
+        { "id": "2.2", "description": "...", "files": [...], "isParallel": true }
+      ],
+      "blockedBy": [1]
+    }
+  ],
+  "totalTasks": 15,
+  "parallelizableTasks": 6,
+  "estimatedGroups": 8
+}
+```
+
+**Store the execution DAG** for Step 6.
+
+---
+
+### Step 6: Execute Implementation
+
+Process each execution group from Step 5:
+
+#### For groups with `canParallelize: true`:
+
+**Spawn parallel code-architect agents** (single message with multiple Task tool calls):
+
+For each [P] task in the group, launch a code-architect agent with:
+```
+Implement this task:
+
+**Task ID**: {task.id}
+**Description**: {task.description}
+**Files to create/modify**: {task.files}
+
+**Context**:
+- Tech Stack: {techStack_from_digest}
+- Architecture Patterns: {architecture.patterns}
+- Critical Constraints: {criticalConstraints}
+
+**Instructions**:
+1. Follow TDD if this is a test task
+2. Match existing code style and patterns
+3. Use the project's existing utilities and abstractions
+4. Implement ONLY what the task specifies - no extras
+
+**Report completion**:
+{
+  "taskId": "{task.id}",
+  "status": "completed" | "failed" | "blocked",
+  "filesCreated": [...],
+  "filesModified": [...],
+  "error": null | "description of issue",
+  "notes": "any important observations"
+}
+```
+
+**Wait for all parallel agents to complete**, then:
+- Collect results from all agents
+- Handle any failures (log error, mark task as incomplete)
+- Proceed to next group
+
+#### For groups with `canParallelize: false`:
+
+**Main agent implements sequentially**:
+- Execute each task in order
+- Use the condensed context from Step 3
+- Follow existing code patterns
+
+#### After each group completion:
+
+**Launch code-reviewer agent** for validation:
+```
+Review the following recently implemented files:
+{files_from_completed_group}
+
+Check for:
+1. Adherence to project conventions (from CLAUDE.md patterns)
+2. Consistency with specification requirements
+3. Potential bugs or logic errors
+4. Security issues (if applicable)
+
+Return:
+{
+  "passed": true | false,
+  "issues": [
+    { "file": "...", "line": N, "severity": "error|warning", "message": "..." }
+  ],
+  "suggestions": [...]
+}
+```
+
+If critical issues found, address them before proceeding.
+
+---
+
+### Step 7: Progress Tracking
+
+After completing each task:
+- Report progress to user
+- **Mark completed tasks** as `[X]` in tasks.md
+- Use Bash agent to update task markers:
+
+```
+Update tasks.md: Change "- [ ] {task.id}" to "- [X] {task.id}" for completed task
+```
+
+**Error handling**:
+- Halt execution if any non-parallel task fails
+- For parallel tasks [P], continue with successful tasks, report failed ones
+- Provide clear error messages with context for debugging
+- Suggest next steps if implementation cannot proceed
+
+---
+
+### Step 8: Final Validation
+
+**Launch code-reviewer agent** for comprehensive validation:
+```
+Perform final implementation validation:
+
+**Implemented files**: {all_files_created_or_modified}
+**Original spec summary**: {digest_from_step_3}
+
+Verify:
+1. All required tasks from tasks.md are completed
+2. Implemented features match the specification
+3. Test coverage meets requirements (if tests exist)
+4. Implementation follows the technical plan architecture
+5. No breaking changes to existing functionality
+
+Return:
+{
+  "validationPassed": true | false,
+  "completedTasks": N,
+  "totalTasks": M,
+  "coverage": { "tested": X, "untested": Y },
+  "issues": [...],
+  "summary": "Implementation complete with X features, Y tests passing"
+}
+```
+
+---
+
+### Step 9: Completion Report
+
+Present final status summary:
+- Total tasks completed vs total tasks
+- Files created/modified
+- Any outstanding issues or warnings
+- Suggestions for next steps (if any tasks incomplete)
+
+---
+
+## Subagent Reference
+
+| Phase | Agent Type | Purpose | Context Passed |
+|-------|------------|---------|----------------|
+| Step 2 | Explore | Checklist scanning | FEATURE_DIR path only |
+| Step 3 | Explore | Spec summarization | FEATURE_DIR, file list |
+| Step 5 | Plan | Execution DAG | Task list from digest |
+| Step 6 | code-architect (parallel) | Task implementation | Single task + condensed context |
+| Step 6 | code-reviewer | Group validation | Implemented files |
+| Step 8 | code-reviewer | Final validation | All files + spec summary |
+
+**Context savings**: Main conversation receives structured digests instead of full file contents, enabling efficient orchestration while subagents handle detailed work.
+
+---
+
+## Notes
+
+- This command assumes a complete task breakdown exists in tasks.md
+- If tasks are incomplete or missing, suggest running `/speckit.tasks` first
+- Parallel execution requires tasks marked with [P] and no file conflicts
+- Each subagent receives focused context for its specific task

--- a/.claude/commands/speckit.plan.md
+++ b/.claude/commands/speckit.plan.md
@@ -1,5 +1,13 @@
 ---
 description: Execute the implementation planning workflow using the plan template to generate design artifacts.
+handoffs:
+  - label: Create Tasks
+    agent: speckit.tasks
+    prompt: Break the plan into tasks
+    send: true
+  - label: Create Checklist
+    agent: speckit.checklist
+    prompt: Create a checklist for the following domain...
 ---
 
 ## User Input
@@ -14,43 +22,78 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+2. **Scope Validation**: Before loading context, verify spec has clear boundaries:
+   - Check FEATURE_SPEC has explicit in-scope and out-of-scope sections
+   - If scope boundaries are missing or ambiguous: ERROR - return user to `/speckit.clarify`
+   - Extract acceptance criteria for later verification planning
 
-3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+3. **Load context** (parallel Read calls in a single message):
+   - FEATURE_SPEC
+   - `.specify/memory/constitution.md`
+   - IMPL_PLAN template (already copied)
+
+4. **Architectural Fit Analysis**: Before executing plan workflow:
+   - Use Task tool with Explore agent to find existing patterns related to the feature
+   - Document which existing patterns to follow vs. where new patterns are needed
+   - This informs research decisions and prevents architectural drift
+
+5. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
    - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
    - Fill Constitution Check section from constitution
-   - Evaluate gates (ERROR if violations unjustified)
+   - Evaluate gates using `mcp__sequential-thinking__sequentialthinking` for complex tradeoffs (ERROR if violations unjustified)
    - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md
    - Phase 1: Update agent context by running the agent script
+   - Phase 2: Execute planning quality gates
    - Re-evaluate Constitution Check post-design
 
-4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+6. **Stop and report**: Command ends after Phase 2 planning. Report:
+   - Branch and IMPL_PLAN path
+   - Generated artifacts
+   - Risk summary (count by severity)
+   - Critical path length
+   - MVP boundary (if applicable)
 
 ## Phases
 
 ### Phase 0: Outline & Research
 
-1. **Extract unknowns from Technical Context** above:
+1. **Validate scope boundaries** from spec.md:
+   - Confirm in-scope items are clearly defined
+   - Confirm out-of-scope items are explicitly listed
+   - If missing: ERROR - return to /speckit.clarify
+
+2. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
-2. **Generate and dispatch research agents**:
+3. **Dispatch research using Task tool** (parallel calls in a single message when independent):
 
    ```text
-   For each unknown in Technical Context:
-     Task: "Research {unknown} for {feature context}"
-   For each technology choice:
-     Task: "Find best practices for {tech} in {domain}"
+   For codebase questions (existing patterns, implementations):
+     Task(subagent_type="Explore", prompt="Find how {pattern} is implemented in this codebase...")
+
+   For architectural fit (REQUIRED for each feature):
+     Task(subagent_type="Explore", prompt="Find existing patterns for {similar functionality} in this codebase. Document: patterns used, files involved, conventions followed.")
+
+   For library/framework documentation:
+     Use Context7 MCP tools (resolve-library-id → query-docs) for up-to-date docs
+
+   For external research (best practices, comparisons, industry patterns):
+     Task(subagent_type="general-purpose", prompt="Research best practices for {tech} in {domain}...")
+     → Agent should use WebSearch for current information
    ```
 
-3. **Consolidate findings** in `research.md` using format:
-   - Decision: [what was chosen]
-   - Rationale: [why chosen]
-   - Alternatives considered: [what else evaluated]
+4. **Consolidate findings** in `research.md` using format:
+   - **Architectural Fit**: Existing patterns to follow, new patterns needed
+   - **Decision**: [what was chosen]
+   - **Rationale**: [why chosen]
+   - **Alternatives considered**: [what else evaluated]
+   - **Dependencies**: Technical deps (libraries, APIs) + Task deps (what blocks what)
+   - **Risk Register**: Identified risks with likelihood/impact/mitigation
 
-**Output**: research.md with all NEEDS CLARIFICATION resolved
+**Output**: research.md with all NEEDS CLARIFICATION resolved, architectural fit documented, dependencies mapped, and risks identified
 
 ### Phase 1: Design & Contracts
 
@@ -66,7 +109,13 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Use standard REST/GraphQL patterns
    - Output OpenAPI/GraphQL schema to `/contracts/`
 
-3. **Agent context update**:
+3. **Generate quickstart.md**:
+   - Step-by-step implementation guide
+   - Based on data-model.md entities and spec requirements
+   - Each step should be atomic and verifiable
+   - Use Explore subagents for parallel file reading when gathering implementation context
+
+4. **Agent context update**:
    - Run `.specify/scripts/bash/update-agent-context.sh claude`
    - These scripts detect which AI agent is in use
    - Update the appropriate agent-specific context file
@@ -75,7 +124,37 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 **Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
 
+### Phase 2: Planning Quality Gates
+
+**Prerequisites:** data-model.md, quickstart.md complete
+
+1. **Critical Path Analysis**:
+   - Identify longest dependency chain in quickstart steps
+   - Flag any step that blocks 3+ downstream steps
+   - Document in plan.md under "Critical Path" section
+
+2. **Testing Strategy**:
+   - For each entity in data-model.md: how to verify?
+   - For each integration point: what test confirms it works?
+   - Output: Add "Testing Approach" section to plan.md
+
+3. **Incremental Delivery Assessment**:
+   - Can feature deliver partial value early?
+   - What's the minimum slice that provides user benefit?
+   - Document MVP boundary if applicable
+
+4. **Risk Review**:
+   - Review Risk Register from research.md
+   - Ensure each HIGH/CRITICAL risk has mitigation
+   - If unmitigated CRITICAL risk: ERROR - cannot proceed
+
+**Output**: Enhanced plan.md with Critical Path, Testing Approach, Delivery Strategy sections
+
 ## Key rules
 
 - Use absolute paths
 - ERROR on gate failures or unresolved clarifications
+- Scope boundaries MUST be validated before research begins
+- Risk Register MUST be generated in Phase 0
+- Testing Strategy MUST be documented before stopping
+- Critical path MUST be identified for features with 5+ quickstart steps

--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -1,5 +1,13 @@
 ---
 description: Create or update the feature specification from a natural language feature description.
+handoffs: 
+  - label: Build Technical Plan
+    agent: speckit.plan
+    prompt: Create a plan for the spec. I am building with...
+  - label: Clarify Spec Requirements
+    agent: speckit.clarify
+    prompt: Clarify specification requirements
+    send: true
 ---
 
 ## User Input
@@ -29,27 +37,28 @@ Given that feature description, do this:
      - "Fix payment processing timeout bug" → "fix-payment-timeout"
 
 2. **Check for existing branches before creating new one**:
-   
+
    a. First, fetch all remote branches to ensure we have the latest information:
+
       ```bash
       git fetch --all --prune
       ```
-   
+
    b. Find the highest feature number across all sources for the short-name:
       - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
       - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
       - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
-   
+
    c. Determine the next available number:
       - Extract all numbers from all three sources
       - Find the highest number N
       - Use N+1 for the new branch number
-   
+
    d. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the calculated number and short-name:
       - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
       - Bash example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" --json --number 5 --short-name "user-auth" "Add user authentication"`
       - PowerShell example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
-   
+
    **IMPORTANT**:
    - Check all three sources (remote branches, local branches, specs directories) to find the highest number
    - Only match branches/directories with the exact short-name pattern

--- a/.claude/commands/speckit.tasks.md
+++ b/.claude/commands/speckit.tasks.md
@@ -1,5 +1,14 @@
 ---
 description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
+handoffs: 
+  - label: Analyze For Consistency
+    agent: speckit.analyze
+    prompt: Run a project analysis for consistency
+    send: true
+  - label: Implement Project
+    agent: speckit.implement
+    prompt: Start the implementation in phases
+    send: true
 ---
 
 ## User Input
@@ -14,7 +23,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. **Load design documents**: Read from FEATURE_DIR:
+2. **Load design documents**: Read from FEATURE_DIR using parallel Read calls in a single message:
    - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
    - **Optional**: data-model.md (entities), contracts/ (API endpoints), research.md (decisions), quickstart.md (test scenarios)
    - Note: Not all projects have all documents. Generate tasks based on what's available.
@@ -30,7 +39,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Create parallel execution examples per user story
    - Validate task completeness (each user story has all needed tasks, independently testable)
 
-4. **Generate tasks.md**: Use `.specify.specify/templates/tasks-template.md` as structure, fill with:
+4. **Generate tasks.md**: Use `.specify/templates/tasks-template.md` as structure, fill with:
    - Correct feature name from plan.md
    - Phase 1: Setup tasks (project initialization)
    - Phase 2: Foundational tasks (blocking prerequisites for all user stories)

--- a/.claude/commands/speckit.taskstoissues.md
+++ b/.claude/commands/speckit.taskstoissues.md
@@ -1,0 +1,30 @@
+---
+description: Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts.
+tools: ['github/github-mcp-server/issue_write']
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. From the executed script, extract the path to **tasks**.
+1. Get the Git remote by running:
+
+```bash
+git config --get remote.origin.url
+```
+
+> [!CAUTION]
+> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+
+1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
+
+> [!CAUTION]
+> UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL

--- a/.specify/scripts/bash/check-prerequisites.sh
+++ b/.specify/scripts/bash/check-prerequisites.sh
@@ -75,7 +75,7 @@ EOF
 done
 
 # Source common functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get feature paths and validate branch

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -7,7 +7,7 @@ get_repo_root() {
         git rev-parse --show-toplevel
     else
         # Fall back to script location for non-git repos
-        local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        local script_dir="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         (cd "$script_dir/../../.." && pwd)
     fi
 }

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -80,41 +80,85 @@ find_repo_root() {
     return 1
 }
 
-# Function to check existing branches (local and remote) and return next available number
-check_existing_branches() {
-    local short_name="$1"
+# Function to get highest number from specs directory
+get_highest_from_specs() {
+    local specs_dir="$1"
+    local highest=0
     
-    # Fetch all remotes to get latest branch info (suppress errors if no remotes)
-    git fetch --all --prune 2>/dev/null || true
-    
-    # Find all branches matching the pattern using git ls-remote (more reliable)
-    local remote_branches=$(git ls-remote --heads origin 2>/dev/null | grep -E "refs/heads/[0-9]+-${short_name}$" | sed 's/.*\/\([0-9]*\)-.*/\1/' | sort -n)
-    
-    # Also check local branches
-    local local_branches=$(git branch 2>/dev/null | grep -E "^[* ]*[0-9]+-${short_name}$" | sed 's/^[* ]*//' | sed 's/-.*//' | sort -n)
-    
-    # Check specs directory as well
-    local spec_dirs=""
-    if [ -d "$SPECS_DIR" ]; then
-        spec_dirs=$(find "$SPECS_DIR" -maxdepth 1 -type d -name "[0-9]*-${short_name}" 2>/dev/null | xargs -n1 basename 2>/dev/null | sed 's/-.*//' | sort -n)
+    if [ -d "$specs_dir" ]; then
+        for dir in "$specs_dir"/*; do
+            [ -d "$dir" ] || continue
+            dirname=$(basename "$dir")
+            number=$(echo "$dirname" | grep -o '^[0-9]\+' || echo "0")
+            number=$((10#$number))
+            if [ "$number" -gt "$highest" ]; then
+                highest=$number
+            fi
+        done
     fi
     
-    # Combine all sources and get the highest number
-    local max_num=0
-    for num in $remote_branches $local_branches $spec_dirs; do
-        if [ "$num" -gt "$max_num" ]; then
-            max_num=$num
-        fi
-    done
+    echo "$highest"
+}
+
+# Function to get highest number from git branches
+get_highest_from_branches() {
+    local highest=0
     
+    # Get all branches (local and remote)
+    branches=$(git branch -a 2>/dev/null || echo "")
+    
+    if [ -n "$branches" ]; then
+        while IFS= read -r branch; do
+            # Clean branch name: remove leading markers and remote prefixes
+            clean_branch=$(echo "$branch" | sed 's/^[* ]*//; s|^remotes/[^/]*/||')
+            
+            # Extract feature number if branch matches pattern ###-*
+            if echo "$clean_branch" | grep -q '^[0-9]\{3\}-'; then
+                number=$(echo "$clean_branch" | grep -o '^[0-9]\{3\}' || echo "0")
+                number=$((10#$number))
+                if [ "$number" -gt "$highest" ]; then
+                    highest=$number
+                fi
+            fi
+        done <<< "$branches"
+    fi
+    
+    echo "$highest"
+}
+
+# Function to check existing branches (local and remote) and return next available number
+check_existing_branches() {
+    local specs_dir="$1"
+
+    # Fetch all remotes to get latest branch info (suppress errors if no remotes)
+    git fetch --all --prune 2>/dev/null || true
+
+    # Get highest number from ALL branches (not just matching short name)
+    local highest_branch=$(get_highest_from_branches)
+
+    # Get highest number from ALL specs (not just matching short name)
+    local highest_spec=$(get_highest_from_specs "$specs_dir")
+
+    # Take the maximum of both
+    local max_num=$highest_branch
+    if [ "$highest_spec" -gt "$max_num" ]; then
+        max_num=$highest_spec
+    fi
+
     # Return next number
     echo $((max_num + 1))
+}
+
+# Function to clean and format a branch name
+clean_branch_name() {
+    local name="$1"
+    echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//'
 }
 
 # Resolve repository root. Prefer git information when available, but fall back
 # to searching for repository markers so the workflow still functions in repositories that
 # were initialised with --no-git.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if git rev-parse --show-toplevel >/dev/null 2>&1; then
     REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -176,14 +220,15 @@ generate_branch_name() {
         echo "$result"
     else
         # Fallback to original logic if no meaningful words found
-        echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//' | tr '-' '\n' | grep -v '^$' | head -3 | tr '\n' '-' | sed 's/-$//'
+        local cleaned=$(clean_branch_name "$description")
+        echo "$cleaned" | tr '-' '\n' | grep -v '^$' | head -3 | tr '\n' '-' | sed 's/-$//'
     fi
 }
 
 # Generate branch name
 if [ -n "$SHORT_NAME" ]; then
     # Use provided short name, just clean it up
-    BRANCH_SUFFIX=$(echo "$SHORT_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//')
+    BRANCH_SUFFIX=$(clean_branch_name "$SHORT_NAME")
 else
     # Generate from description with smart filtering
     BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
@@ -193,24 +238,16 @@ fi
 if [ -z "$BRANCH_NUMBER" ]; then
     if [ "$HAS_GIT" = true ]; then
         # Check existing branches on remotes
-        BRANCH_NUMBER=$(check_existing_branches "$BRANCH_SUFFIX")
+        BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
     else
         # Fall back to local directory check
-        HIGHEST=0
-        if [ -d "$SPECS_DIR" ]; then
-            for dir in "$SPECS_DIR"/*; do
-                [ -d "$dir" ] || continue
-                dirname=$(basename "$dir")
-                number=$(echo "$dirname" | grep -o '^[0-9]\+' || echo "0")
-                number=$((10#$number))
-                if [ "$number" -gt "$HIGHEST" ]; then HIGHEST=$number; fi
-            done
-        fi
+        HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
         BRANCH_NUMBER=$((HIGHEST + 1))
     fi
 fi
 
-FEATURE_NUM=$(printf "%03d" "$BRANCH_NUMBER")
+# Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
+FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
 BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
 
 # GitHub enforces a 244-byte limit on branch names

--- a/.specify/scripts/bash/setup-plan.sh
+++ b/.specify/scripts/bash/setup-plan.sh
@@ -24,7 +24,7 @@ for arg in "$@"; do
 done
 
 # Get script directory and load common functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get all paths and variables from common functions

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -30,12 +30,12 @@
 #
 # 5. Multi-Agent Support
 #    - Handles agent-specific file paths and naming conventions
-#    - Supports: Claude, Gemini, Copilot, Cursor, Qwen, opencode, Codex, Windsurf, Kilo Code, Auggie CLI, Roo Code, CodeBuddy CLI, Amp, or Amazon Q Developer CLI
+#    - Supports: Claude, Gemini, Copilot, Cursor, Qwen, opencode, Codex, Windsurf, Kilo Code, Auggie CLI, Roo Code, CodeBuddy CLI, Qoder CLI, Amp, SHAI, or Amazon Q Developer CLI
 #    - Can update single agents or all existing agent files
 #    - Creates default Claude file if no agent files exist
 #
 # Usage: ./update-agent-context.sh [agent_type]
-# Agent types: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|q
+# Agent types: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|shai|q|bob|qoder
 # Leave empty to update all existing agent files
 
 set -e
@@ -49,7 +49,7 @@ set -o pipefail
 #==============================================================================
 
 # Get script directory and load common functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get all paths and variables from common functions
@@ -61,7 +61,7 @@ AGENT_TYPE="${1:-}"
 # Agent-specific file paths  
 CLAUDE_FILE="$REPO_ROOT/CLAUDE.md"
 GEMINI_FILE="$REPO_ROOT/GEMINI.md"
-COPILOT_FILE="$REPO_ROOT/.github/copilot-instructions.md"
+COPILOT_FILE="$REPO_ROOT/.github/agents/copilot-instructions.md"
 CURSOR_FILE="$REPO_ROOT/.cursor/rules/specify-rules.mdc"
 QWEN_FILE="$REPO_ROOT/QWEN.md"
 AGENTS_FILE="$REPO_ROOT/AGENTS.md"
@@ -70,8 +70,11 @@ KILOCODE_FILE="$REPO_ROOT/.kilocode/rules/specify-rules.md"
 AUGGIE_FILE="$REPO_ROOT/.augment/rules/specify-rules.md"
 ROO_FILE="$REPO_ROOT/.roo/rules/specify-rules.md"
 CODEBUDDY_FILE="$REPO_ROOT/CODEBUDDY.md"
+QODER_FILE="$REPO_ROOT/QODER.md"
 AMP_FILE="$REPO_ROOT/AGENTS.md"
+SHAI_FILE="$REPO_ROOT/SHAI.md"
 Q_FILE="$REPO_ROOT/AGENTS.md"
+BOB_FILE="$REPO_ROOT/AGENTS.md"
 
 # Template file
 TEMPLATE_FILE="$REPO_ROOT/.specify/templates/agent-file-template.md"
@@ -615,15 +618,24 @@ update_specific_agent() {
         codebuddy)
             update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
             ;;
+        qoder)
+            update_agent_file "$QODER_FILE" "Qoder CLI"
+            ;;
         amp)
             update_agent_file "$AMP_FILE" "Amp"
+            ;;
+        shai)
+            update_agent_file "$SHAI_FILE" "SHAI"
             ;;
         q)
             update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
             ;;
+        bob)
+            update_agent_file "$BOB_FILE" "IBM Bob"
+            ;;
         *)
             log_error "Unknown agent type '$agent_type'"
-            log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|amp|q"
+            log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|amp|shai|q|bob|qoder"
             exit 1
             ;;
     esac
@@ -688,8 +700,23 @@ update_all_existing_agents() {
         found_agent=true
     fi
 
+    if [[ -f "$SHAI_FILE" ]]; then
+        update_agent_file "$SHAI_FILE" "SHAI"
+        found_agent=true
+    fi
+
+    if [[ -f "$QODER_FILE" ]]; then
+        update_agent_file "$QODER_FILE" "Qoder CLI"
+        found_agent=true
+    fi
+
     if [[ -f "$Q_FILE" ]]; then
         update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
+        found_agent=true
+    fi
+    
+    if [[ -f "$BOB_FILE" ]]; then
+        update_agent_file "$BOB_FILE" "IBM Bob"
         found_agent=true
     fi
     
@@ -717,7 +744,7 @@ print_summary() {
     
     echo
 
-    log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|codebuddy|q]"
+    log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|codebuddy|shai|q|bob|qoder]"
 }
 
 #==============================================================================

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -102,3 +102,35 @@ directories captured above]
 |-----------|------------|-------------------------------------|
 | [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
 | [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |
+
+## Critical Path
+
+> **Phase 2 output**: Identifies the longest dependency chain and bottleneck steps
+
+**Longest Chain**: [Number of steps in critical path]
+
+| Step | Description | Blocks |
+|------|-------------|--------|
+| [step #] | [what it does] | [steps that depend on it] |
+
+**Bottleneck Steps** (blocks 3+ downstream steps):
+- [List any steps that are critical bottlenecks]
+
+## Testing Approach
+
+> **Phase 2 output**: Verification strategy for each component
+
+| Component | Verification Method | Success Criteria |
+|-----------|-------------------|------------------|
+| [entity/integration] | [unit/integration/manual] | [what confirms it works] |
+
+## Delivery Strategy
+
+> **Phase 2 output**: Fill if feature can be delivered incrementally
+
+**MVP Boundary**: [Minimum slice that provides user value, or "N/A - atomic feature"]
+
+**Incremental Slices** (if applicable):
+1. [First deliverable slice]
+2. [Second deliverable slice]
+3. [Full feature]


### PR DESCRIPTION
## Summary
- Add handoffs to command frontmatter for workflow transitions (specify→plan→tasks→implement)
- Switch clarify/checklist to use AskUserQuestion tool for structured user input
- Increase clarify question limit from 5→8 with batched presentation (up to 4 at a time)
- Rewrite implement.md to use subagent delegation (Explore, Plan, code-architect agents)
- Add scope validation, architectural fit analysis, and quality gates to plan workflow
- Add new speckit.taskstoissues command to convert tasks to GitHub issues
- Fix bash scripts: add CDPATH="" prefix for reliable directory resolution
- Improve branch numbering: check ALL branches/specs, not just matching short-name
- Add support for new AI agents: SHAI, Qoder CLI, IBM Bob
- Update plan-template with Critical Path, Testing Approach, Delivery Strategy sections

## Test plan
- [x] Changes are internal workflow improvements (commands, scripts, templates)
- [x] No runtime code affected