### PR TITLE
feat(ui): dashboard visual hierarchy, typography & accessibility polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,6 +504,8 @@ Use `Sentry.createConsolaReporter()` (reporter pattern), not `consolaIntegration
 ## Active Technologies
 - TypeScript 5 / Vue 3 / Nuxt 4 + Nuxt UI 4 (UModal, UTable, UTooltip), TanStack Query (Vue Query) (008-stint-progress-modal)
 - Supabase PostgreSQL (existing `stints` table — read-only access, no migrations) (008-stint-progress-modal)
+- TypeScript 5 / Vue 3 / Nuxt 4 + Nuxt UI 4 (Reka UI), Tailwind CSS v4, Google Fonts (Fraunces, Instrument Sans) (009-dashboard-ui-polish)
+- N/A — no database changes (009-dashboard-ui-polish)
 
 ## Recent Changes
 - 008-stint-progress-modal: Added TypeScript 5 / Vue 3 / Nuxt 4 + Nuxt UI 4 (UModal, UTable, UTooltip), TanStack Query (Vue Query)

--- a/app/assets/css/tokens.css
+++ b/app/assets/css/tokens.css
@@ -30,7 +30,10 @@
   /* Text */
   --text-primary: #292524;
   --text-secondary: #57534e;
-  --text-muted: #a8a29e;
+  --text-muted: #736b66;
+
+  /* Active Row */
+  --bg-active-row: rgba(22, 163, 74, 0.05);
 
   /* Accents */
   --accent-primary: #c2410c;
@@ -63,7 +66,10 @@
   /* Text */
   --text-primary: #fafaf9;
   --text-secondary: #d6d3d1;
-  --text-muted: #78716c;
+  --text-muted: #908984;
+
+  /* Active Row */
+  --bg-active-row: rgba(34, 197, 94, 0.08);
 
   /* Accents */
   --accent-primary: #ea580c;

--- a/app/components/ArchivedProjectsList.vue
+++ b/app/components/ArchivedProjectsList.vue
@@ -100,7 +100,7 @@ async function handlePermanentDelete() {
         class="h-12 w-12 mx-auto text-amber-500 dark:text-amber-400"
         aria-hidden="true"
       />
-      <h3 class="mt-4 font-serif text-lg font-medium text-stone-900 dark:text-stone-100">
+      <h3 class="mt-4 text-lg font-medium text-stone-900 dark:text-stone-100">
         Your archive is empty
       </h3>
       <p class="mt-2 text-sm text-stone-500 dark:text-stone-400">

--- a/app/components/DashboardTimerHero.vue
+++ b/app/components/DashboardTimerHero.vue
@@ -127,7 +127,7 @@ function handleComplete(stint: StintRow) {
     <!-- Active Session State -->
     <div class="session-content">
       <div class="session-header">
-        <h2 class="session-project font-serif">
+        <h2 class="session-project">
           {{ displayProjectName }}
         </h2>
       </div>
@@ -330,7 +330,7 @@ function handleComplete(stint: StintRow) {
 }
 
 .meta-label {
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -356,7 +356,7 @@ function handleComplete(stint: StintRow) {
   font-size: 48px;
   font-weight: 600;
   color: var(--text-primary);
-  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
   line-height: 1;
   text-shadow: 0 0 40px var(--accent-primary-glow);
 }

--- a/app/components/ProjectList.vue
+++ b/app/components/ProjectList.vue
@@ -500,7 +500,7 @@ async function handleConflictResolution(action: ConflictResolutionAction): Promi
         class="h-12 w-12 mx-auto text-stone-400 dark:text-stone-600"
         aria-hidden="true"
       />
-      <h3 class="mt-4 font-serif text-lg font-medium text-stone-900 dark:text-stone-100">
+      <h3 class="mt-4 text-lg font-medium text-stone-900 dark:text-stone-100">
         Start your first project
       </h3>
       <p class="mt-2 text-sm text-stone-500 dark:text-stone-400">
@@ -526,7 +526,7 @@ async function handleConflictResolution(action: ConflictResolutionAction): Promi
         class="h-12 w-12 mx-auto text-stone-400 dark:text-stone-600"
         aria-hidden="true"
       />
-      <h3 class="mt-4 font-serif text-lg font-medium text-stone-900 dark:text-stone-100">
+      <h3 class="mt-4 text-lg font-medium text-stone-900 dark:text-stone-100">
         No active projects
       </h3>
       <p class="mt-2 text-sm text-stone-500 dark:text-stone-400">
@@ -553,7 +553,7 @@ async function handleConflictResolution(action: ConflictResolutionAction): Promi
         class="h-12 w-12 mx-auto text-green-500 dark:text-green-400"
         aria-hidden="true"
       />
-      <h3 class="mt-4 font-serif text-lg font-medium text-stone-900 dark:text-stone-100">
+      <h3 class="mt-4 text-lg font-medium text-stone-900 dark:text-stone-100">
         All projects are active
       </h3>
       <p class="mt-2 text-sm text-stone-500 dark:text-stone-400">

--- a/app/components/ProjectListCard.vue
+++ b/app/components/ProjectListCard.vue
@@ -84,24 +84,24 @@ const extraStints = computed(() => {
   return 0;
 });
 
-const colorRingClass = computed(() => {
+const colorDotClass = computed(() => {
   const color = props.project.color_tag;
   if (!color || !PROJECT.COLORS.includes(color as ProjectColor)) {
-    return 'border-stone-400 dark:border-stone-500';
+    return 'bg-stone-400 dark:bg-stone-500';
   }
 
-  const ringColorMap: Record<ProjectColor, string> = {
-    red: 'border-red-500',
-    orange: 'border-orange-500',
-    amber: 'border-amber-500',
-    green: 'border-green-500',
-    teal: 'border-teal-500',
-    blue: 'border-blue-500',
-    purple: 'border-purple-500',
-    pink: 'border-pink-500',
+  const dotColorMap: Record<ProjectColor, string> = {
+    red: 'bg-red-500',
+    orange: 'bg-orange-500',
+    amber: 'bg-amber-500',
+    green: 'bg-green-500',
+    teal: 'bg-teal-500',
+    blue: 'bg-blue-500',
+    purple: 'bg-purple-500',
+    pink: 'bg-pink-500',
   };
 
-  return ringColorMap[color as ProjectColor];
+  return dotColorMap[color as ProjectColor];
 });
 
 const canStartStint = computed(() => props.project.is_active && !hasActiveStint.value);
@@ -166,7 +166,7 @@ function handleCompleteStint() {
     <div class="project-color-wrapper">
       <div
         class="project-color"
-        :class="colorRingClass"
+        :class="colorDotClass"
       />
       <span
         v-if="hasPausedStint || (hasActiveStint && isPaused)"
@@ -302,8 +302,8 @@ function handleCompleteStint() {
 .card-v27 {
   display: flex;
   align-items: center;
-  gap: 14px;
-  padding: 14px 20px;
+  gap: 12px;
+  padding: 12px 20px;
   background: rgba(255, 255, 255, 0.5);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
@@ -319,6 +319,7 @@ function handleCompleteStint() {
 }
 
 .card-v27.state-running {
+  background: var(--bg-active-row);
   box-shadow: 0 2px 12px rgba(22, 163, 74, 0.1);
 }
 
@@ -375,13 +376,10 @@ function handleCompleteStint() {
 }
 
 .project-color {
-  width: 18px;
-  height: 18px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
   flex-shrink: 0;
-  background: transparent;
-  border-width: 3.5px;
-  border-style: solid;
 }
 
 .paused-indicator {

--- a/app/layouts/component-gallery.vue
+++ b/app/layouts/component-gallery.vue
@@ -24,7 +24,7 @@ function toggleDarkMode() {
             <span class="text-sm font-medium">Back</span>
           </NuxtLink>
           <div class="h-6 w-px bg-stone-200 dark:bg-stone-700" />
-          <h1 class="text-xl font-bold font-serif text-stone-900 dark:text-white">
+          <h1 class="text-xl font-bold text-stone-900 dark:text-white">
             Component Gallery
           </h1>
         </div>

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -119,7 +119,7 @@ onMounted(() => {
               name="i-lucide-loader-2"
               class="w-8 h-8 mx-auto text-orange-600 animate-spin dark:text-orange-500"
             />
-            <h2 class="text-xl font-serif font-semibold">
+            <h2 class="text-xl font-semibold">
               Verifying your account...
             </h2>
             <p class="text-stone-600 dark:text-stone-400">
@@ -135,7 +135,7 @@ onMounted(() => {
               name="i-lucide-triangle-alert"
               class="w-8 h-8 mx-auto text-red-500 dark:text-red-400"
             />
-            <h2 class="text-xl font-serif font-semibold">
+            <h2 class="text-xl font-semibold">
               Authentication Error
             </h2>
             <p class="text-stone-600 dark:text-stone-400">
@@ -167,7 +167,7 @@ onMounted(() => {
               name="i-lucide-circle-check"
               class="w-8 h-8 mx-auto text-green-600 dark:text-green-500"
             />
-            <h2 class="text-xl font-serif font-semibold">
+            <h2 class="text-xl font-semibold">
               Welcome to LifeStint!
             </h2>
             <p class="text-stone-600 dark:text-stone-400">

--- a/app/pages/auth/forgot-password.vue
+++ b/app/pages/auth/forgot-password.vue
@@ -13,7 +13,7 @@
             />
             <span class="text-sm font-medium">Back to home</span>
           </NuxtLink>
-          <h2 class="text-3xl font-serif font-semibold text-stone-800 dark:text-stone-50">
+          <h2 class="text-3xl font-semibold text-stone-800 dark:text-stone-50">
             Reset your password
           </h2>
           <p class="text-sm text-stone-600 dark:text-stone-400">

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -104,7 +104,7 @@ watch(() => state.password, () => {
               </span>
             </NuxtLink>
 
-            <h2 class="text-3xl font-serif font-semibold text-stone-800 dark:text-stone-50">
+            <h2 class="text-3xl font-semibold text-stone-800 dark:text-stone-50">
               Welcome back
             </h2>
             <p class="text-sm text-stone-600 dark:text-stone-400">

--- a/app/pages/auth/register.vue
+++ b/app/pages/auth/register.vue
@@ -174,7 +174,7 @@ watch([() => state.email, () => state.password, () => state.confirmPassword], ()
               </span>
             </NuxtLink>
 
-            <h2 class="text-3xl font-serif font-semibold text-stone-800 dark:text-stone-50">
+            <h2 class="text-3xl font-semibold text-stone-800 dark:text-stone-50">
               Create your account
             </h2>
             <p class="text-sm text-stone-600 dark:text-stone-400">

--- a/app/pages/auth/reset-password.vue
+++ b/app/pages/auth/reset-password.vue
@@ -13,7 +13,7 @@
             />
             <span class="text-sm font-medium">Back to home</span>
           </NuxtLink>
-          <h2 class="text-3xl font-serif font-semibold text-stone-800 dark:text-stone-50">
+          <h2 class="text-3xl font-semibold text-stone-800 dark:text-stone-50">
             Set your new password
           </h2>
           <p class="text-sm text-stone-600 dark:text-stone-400">

--- a/app/pages/auth/verify-email.vue
+++ b/app/pages/auth/verify-email.vue
@@ -13,7 +13,7 @@
             />
             <span class="text-sm font-medium">Back to home</span>
           </NuxtLink>
-          <h2 class="text-3xl font-serif font-semibold text-stone-800 dark:text-stone-50">
+          <h2 class="text-3xl font-semibold text-stone-800 dark:text-stone-50">
             Check your email
           </h2>
           <p class="text-sm text-stone-600 dark:text-stone-400">

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -224,7 +224,7 @@ async function handleConfirmComplete(payload: { notes: string, attributedDate?: 
         >
           <!-- Header -->
           <div class="flex items-center justify-between">
-            <h2 class="text-xl lg:text-2xl font-semibold font-serif text-stone-900 dark:text-stone-50">
+            <h2 class="text-xl lg:text-2xl font-semibold text-stone-900 dark:text-stone-50">
               Your Projects
             </h2>
             <UButton
@@ -255,6 +255,8 @@ async function handleConfirmComplete(payload: { notes: string, attributedDate?: 
             v-if="!isLoading"
             v-model="selectedTab"
             :items="tabItems"
+            variant="link"
+            color="neutral"
             class="w-full"
           >
             <template #active>

--- a/app/pages/gallery.vue
+++ b/app/pages/gallery.vue
@@ -171,7 +171,7 @@ const mockExistingStint = {
             class="scroll-mt-24"
           >
             <div class="mb-6">
-              <h2 class="text-2xl font-bold font-serif text-stone-900 dark:text-white mb-2">
+              <h2 class="text-2xl font-bold text-stone-900 dark:text-white mb-2">
                 ProjectListCard
               </h2>
               <p class="text-stone-600 dark:text-stone-400">
@@ -254,7 +254,7 @@ const mockExistingStint = {
             class="scroll-mt-24"
           >
             <div class="mb-6">
-              <h2 class="text-2xl font-bold font-serif text-stone-900 dark:text-white mb-2">
+              <h2 class="text-2xl font-bold text-stone-900 dark:text-white mb-2">
                 StreakBanner
               </h2>
               <p class="text-stone-600 dark:text-stone-400">
@@ -331,7 +331,7 @@ const mockExistingStint = {
             class="scroll-mt-24"
           >
             <div class="mb-6">
-              <h2 class="text-2xl font-bold font-serif text-stone-900 dark:text-white mb-2">
+              <h2 class="text-2xl font-bold text-stone-900 dark:text-white mb-2">
                 StintTimer
               </h2>
               <p class="text-stone-600 dark:text-stone-400">
@@ -397,7 +397,7 @@ const mockExistingStint = {
             class="scroll-mt-24"
           >
             <div class="mb-6">
-              <h2 class="text-2xl font-bold font-serif text-stone-900 dark:text-white mb-2">
+              <h2 class="text-2xl font-bold text-stone-900 dark:text-white mb-2">
                 ProjectForm
               </h2>
               <p class="text-stone-600 dark:text-stone-400">
@@ -437,7 +437,7 @@ const mockExistingStint = {
             class="scroll-mt-24"
           >
             <div class="mb-6">
-              <h2 class="text-2xl font-bold font-serif text-stone-900 dark:text-white mb-2">
+              <h2 class="text-2xl font-bold text-stone-900 dark:text-white mb-2">
                 Modals & Dialogs
               </h2>
               <p class="text-stone-600 dark:text-stone-400">

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -153,7 +153,7 @@ onUnmounted(() => {
               <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-orange-100 dark:bg-orange-900/30 border border-orange-200 dark:border-orange-700/50 text-sm text-orange-800 dark:text-orange-200 fade-up stagger-1">
                 Built for freelancers, consultants, and independents
               </div>
-              <h1 class="mt-5 text-4xl sm:text-5xl xl:text-6xl font-semibold leading-tight fade-up stagger-2 font-serif text-stone-900 dark:text-stone-50">
+              <h1 class="mt-5 text-4xl sm:text-5xl xl:text-6xl font-semibold leading-tight fade-up stagger-2 text-stone-900 dark:text-stone-50">
                 One stint at a time.<br>Zero context switching.
               </h1>
               <p class="mt-5 text-stone-600 dark:text-stone-300 text-lg max-w-2xl fade-up stagger-3">
@@ -333,7 +333,7 @@ onUnmounted(() => {
         <div class="text-center max-w-3xl mx-auto mb-10">
           <h2
             id="how-it-works-title"
-            class="text-3xl sm:text-4xl font-semibold font-serif text-stone-900 dark:text-stone-50"
+            class="text-3xl sm:text-4xl font-semibold text-stone-900 dark:text-stone-50"
           >
             Run your day in stints
           </h2>
@@ -501,7 +501,7 @@ onUnmounted(() => {
     <section class="relative">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14">
         <div class="text-center max-w-3xl mx-auto mb-10 fade-up">
-          <h2 class="text-3xl sm:text-4xl font-semibold font-serif text-stone-900 dark:text-stone-50">
+          <h2 class="text-3xl sm:text-4xl font-semibold text-stone-900 dark:text-stone-50">
             Why not just use a time tracker?
           </h2>
           <p class="mt-3 text-stone-600 dark:text-stone-300 text-lg">
@@ -798,7 +798,7 @@ onUnmounted(() => {
         <div class="rounded-3xl bg-white dark:bg-stone-800 ring-1 ring-stone-200 dark:ring-stone-700 p-6 sm:p-10 shadow-lg">
           <div class="grid lg:grid-cols-2 gap-10 items-center">
             <div>
-              <h3 class="text-3xl font-semibold font-serif text-stone-900 dark:text-stone-50">
+              <h3 class="text-3xl font-semibold text-stone-900 dark:text-stone-50">
                 Focus evidence clients respect
               </h3>
               <p class="mt-3 text-stone-600 dark:text-stone-300 text-lg">
@@ -990,7 +990,7 @@ onUnmounted(() => {
           id="cta"
           class="mt-10 rounded-2xl bg-[#fffbf5] dark:bg-stone-800 border-3 border-orange-500 dark:border-orange-600 p-8 sm:p-10 text-center scale-in"
         >
-          <h3 class="text-3xl font-bold text-stone-900 dark:text-stone-50 font-serif">
+          <h3 class="text-3xl font-bold text-stone-900 dark:text-stone-50">
             Start demonstrating your focus quality
           </h3>
           <p class="mt-3 text-stone-600 dark:text-stone-300 text-lg max-w-2xl mx-auto">
@@ -1019,7 +1019,7 @@ onUnmounted(() => {
     >
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14">
         <div class="text-center">
-          <h3 class="text-3xl sm:text-4xl font-semibold font-serif text-stone-900 dark:text-stone-50">
+          <h3 class="text-3xl sm:text-4xl font-semibold text-stone-900 dark:text-stone-50">
             Simple pricing for serious focus
           </h3>
           <p class="mt-3 text-stone-600 dark:text-stone-300 text-lg">
@@ -1263,7 +1263,7 @@ onUnmounted(() => {
       class="relative bg-[#fef7ed] dark:bg-stone-800/50"
     >
       <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-14">
-        <h3 class="text-3xl sm:text-4xl font-semibold text-center font-serif text-stone-900 dark:text-stone-50">
+        <h3 class="text-3xl sm:text-4xl font-semibold text-center text-stone-900 dark:text-stone-50">
           Frequently asked questions
         </h3>
         <div class="mt-10 grid md:grid-cols-2 gap-6">

--- a/app/pages/legal/privacy.vue
+++ b/app/pages/legal/privacy.vue
@@ -28,7 +28,7 @@ useSeoMeta({
 
     <!-- Content -->
     <main class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-      <h1 class="text-3xl sm:text-4xl font-semibold font-serif text-stone-900 dark:text-stone-50">
+      <h1 class="text-3xl sm:text-4xl font-semibold text-stone-900 dark:text-stone-50">
         Privacy Policy
       </h1>
       <p class="mt-2 text-stone-500 dark:text-stone-400">

--- a/app/pages/legal/terms.vue
+++ b/app/pages/legal/terms.vue
@@ -28,7 +28,7 @@ useSeoMeta({
 
     <!-- Content -->
     <main class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-      <h1 class="text-3xl sm:text-4xl font-semibold font-serif text-stone-900 dark:text-stone-50">
+      <h1 class="text-3xl sm:text-4xl font-semibold text-stone-900 dark:text-stone-50">
         Terms of Service
       </h1>
       <p class="mt-2 text-stone-500 dark:text-stone-400">

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -67,8 +67,8 @@ All design tokens are defined in `app/assets/css/tokens.css` with semantic CSS v
 
 #### Typography Tokens
 ```css
---font-serif: 'Fraunces', Georgia, serif;      /* Headings */
---font-sans: 'Instrument Sans', system-ui, sans-serif;  /* Body */
+--font-serif: 'Fraunces', Georgia, serif;      /* LifeStint logo only */
+--font-sans: 'Instrument Sans', system-ui, sans-serif;  /* Headings, body, UI elements */
 --font-mono: 'JetBrains Mono', monospace;      /* Timers, code */
 ```
 
@@ -99,7 +99,7 @@ All design tokens are defined in `app/assets/css/tokens.css` with semantic CSS v
 /* Text */
 --text-primary: #292524;      /* Stone-800 equivalent */
 --text-secondary: #57534e;    /* Stone-600 equivalent */
---text-muted: #a8a29e;        /* Stone-400 equivalent */
+--text-muted: #736b66;        /* Stone-400 equivalent */
 
 /* Accents */
 --accent-primary: #c2410c;    /* Terracotta - main accent */
@@ -112,6 +112,9 @@ All design tokens are defined in `app/assets/css/tokens.css` with semantic CSS v
 /* Borders */
 --border-light: #e7e5e4;      /* Stone-200 */
 --border-medium: #d6d3d1;     /* Stone-300 */
+
+/* Active Row */
+--bg-active-row: rgba(22, 163, 74, 0.05);     /* Background for active running project row */
 
 /* Shadows */
 --shadow-soft: 0 4px 20px rgba(120, 113, 108, 0.08);
@@ -131,7 +134,7 @@ All design tokens are defined in `app/assets/css/tokens.css` with semantic CSS v
 /* Text */
 --text-primary: #fafaf9;      /* Stone-50 */
 --text-secondary: #d6d3d1;    /* Stone-300 */
---text-muted: #78716c;        /* Stone-500 */
+--text-muted: #908984;        /* Stone-500 */
 
 /* Accents */
 --accent-primary: #ea580c;    /* Brighter orange for dark mode */
@@ -144,6 +147,9 @@ All design tokens are defined in `app/assets/css/tokens.css` with semantic CSS v
 /* Borders */
 --border-light: #3d3835;
 --border-medium: #4a4543;
+
+/* Active Row */
+--bg-active-row: rgba(34, 197, 94, 0.08);     /* Background for active running project row */
 
 /* Shadows */
 --shadow-soft: 0 4px 20px rgba(0, 0, 0, 0.3);
@@ -183,7 +189,7 @@ The design system uses warm, earthy tones mapped to semantic purposes:
 | **Card** | White `#ffffff` | Stone-800 `#292524` | Custom | Card surfaces |
 | **Text Primary** | Stone-800 `#292524` | Stone-50 `#fafaf9` | `stone-800/50` | Main text |
 | **Text Secondary** | Stone-600 `#57534e` | Stone-300 `#d6d3d1` | `stone-600/300` | Secondary text |
-| **Text Muted** | Stone-400 `#a8a29e` | Stone-500 `#78716c` | `stone-400/500` | Muted text |
+| **Text Muted** | `#736b66` | `#908984` | `stone-400/500` | Muted text |
 | **Warning** | Amber `#d97706` | Amber `#fbbf24` | `amber-600/400` | Warnings, pause states |
 | **Error/Danger** | Red `#dc2626` | Red `#f87171` | `red-600/400` | Errors, destructive actions |
 | **Border Light** | Stone-200 `#e7e5e4` | Custom `#3d3835` | `stone-200` | Light borders |
@@ -200,7 +206,7 @@ The design system uses warm, earthy tones mapped to semantic purposes:
 
 <!-- Custom styling with tokens -->
 <div class="bg-[var(--bg-primary)] border-[var(--border-light)]">
-  <h2 class="text-[var(--accent-primary)] font-serif">Project Name</h2>
+  <h2 class="text-[var(--accent-primary)]">Project Name</h2>
 </div>
 
 <!-- Direct Tailwind with stone palette -->
@@ -241,8 +247,8 @@ The design system uses a distinctive typographic hierarchy with three font famil
 
 | Font | Variable | Usage | Characteristics |
 |------|----------|-------|-----------------|
-| **Fraunces** | `--font-serif` | Headings, display text | Warm, friendly serif with optical sizing |
-| **Instrument Sans** | `--font-sans` | Body text, UI elements | Clean, modern sans-serif |
+| **Fraunces** | `--font-serif` | LifeStint logo only | Warm, friendly serif with optical sizing |
+| **Instrument Sans** | `--font-sans` | All headings, body text, UI elements | Clean, modern sans-serif |
 | **JetBrains Mono** | `--font-mono` | Timers, code, numbers | Monospace with ligatures |
 
 ```css
@@ -273,16 +279,16 @@ The design system uses a distinctive typographic hierarchy with three font famil
 
 ### Typography Patterns
 
-**Page Title (Fraunces Serif):**
+**Page Title (Instrument Sans):**
 ```vue
-<h1 class="font-serif text-3xl font-bold text-stone-800 dark:text-stone-50">
+<h1 class="text-3xl font-bold text-stone-800 dark:text-stone-50">
   Dashboard
 </h1>
 ```
 
 **Section Header:**
 ```vue
-<h2 class="font-serif text-2xl font-semibold text-stone-800 dark:text-stone-100">
+<h2 class="text-2xl font-semibold text-stone-800 dark:text-stone-100">
   Active Projects
 </h2>
 ```
@@ -424,7 +430,7 @@ Container component for grouping related content with warm shadows.
 ```vue
 <UCard class="bg-white dark:bg-stone-800 shadow-warm">
   <template #header>
-    <h3 class="font-serif text-lg font-semibold">Card Title</h3>
+    <h3 class="text-lg font-semibold">Card Title</h3>
   </template>
   <p class="text-stone-700 dark:text-stone-300">Card content</p>
   <template #footer>
@@ -535,7 +541,7 @@ Uses Tailwind's default 4px base unit:
 |-------|-------|-------|
 | `gap-1` | 4px | Tight inline spacing |
 | `gap-2` | 8px | Default inline spacing |
-| `gap-3` | 12px | Component spacing |
+| `gap-3` | 12px | Component spacing, card gap |
 | `gap-4` | 16px | Section spacing |
 | `gap-6` | 24px | Large section spacing |
 | `gap-8` | 32px | Page section spacing |
@@ -799,7 +805,7 @@ Always respect `prefers-reduced-motion`:
     name="i-lucide-folder-open"
     class="h-12 w-12 mx-auto text-stone-400 dark:text-stone-600"
   />
-  <h3 class="mt-4 font-serif text-lg font-medium text-stone-900 dark:text-stone-100">
+  <h3 class="mt-4 text-lg font-medium text-stone-900 dark:text-stone-100">
     No projects yet
   </h3>
   <p class="mt-2 text-sm text-stone-500 dark:text-stone-400">
@@ -904,6 +910,21 @@ toast.add({
 </div>
 ```
 
+### Project Color Indicators
+
+Project color indicators use **12px solid filled dots** to visually associate a project with its assigned color:
+
+```vue
+<span
+  class="inline-block h-3 w-3 rounded-full flex-shrink-0"
+  :style="{ backgroundColor: project.color }"
+/>
+```
+
+- **Size**: 12px (`h-3 w-3`)
+- **Shape**: Full circle (`rounded-full`)
+- **Style**: Solid filled (not hollow rings or borders)
+
 ### Stint Action Buttons
 
 Project list cards use custom-styled action buttons for stint control:
@@ -935,13 +956,16 @@ Project list cards use custom-styled action buttons for stint control:
 | **Danger** | `#dc2626` | `#f87171` | `--accent-danger` |
 | **Page Background** | `#fffbf5` | `#1c1917` | `--bg-primary` |
 | **Card Background** | `#ffffff` | `#292524` | `--bg-card` |
+| **Active Row Background** | `rgba(22,163,74,0.05)` | `rgba(34,197,94,0.08)` | `--bg-active-row` |
 | **Text Primary** | `#292524` | `#fafaf9` | `--text-primary` |
 | **Text Secondary** | `#57534e` | `#d6d3d1` | `--text-secondary` |
+| **Text Muted** | `#736b66` | `#908984` | `--text-muted` |
 | **Border Light** | `#e7e5e4` | `#3d3835` | `--border-light` |
 
 ### Typography Summary
 
-- **Headings**: Fraunces (serif) - `font-serif`
+- **Logo**: Fraunces (serif) - `font-serif` (LifeStint logo only)
+- **Headings**: Instrument Sans - `font-sans`
 - **Body**: Instrument Sans - `font-sans`
 - **Mono**: JetBrains Mono - `font-mono`
 - **Timer**: `font-mono text-5xl tabular-nums`
@@ -985,9 +1009,9 @@ Project list cards use custom-styled action buttons for stint control:
 
 **Semantic Heading Hierarchy:**
 ```vue
-<h1 class="font-serif text-3xl font-bold">Dashboard</h1>
+<h1 class="text-3xl font-bold">Dashboard</h1>
 <section>
-  <h2 class="font-serif text-2xl font-semibold">Active Projects</h2>
+  <h2 class="text-2xl font-semibold">Active Projects</h2>
   <article>
     <h3 class="text-lg font-semibold">Client Website</h3>
   </article>
@@ -1019,7 +1043,7 @@ nuxt.config.ts                # Nuxt config (UI module, color mode)
 1. **Use CSS Tokens**: Prefer `var(--token-name)` for design system values
 2. **Semantic Colors**: Use `color="primary"` not `color="orange"` in components
 3. **Dark Mode**: Always include `dark:` variants for custom styling
-4. **Typography**: Use `font-serif` for headings, `font-mono` for timers
+4. **Typography**: Use `font-sans` for headings and body text, `font-serif` only for the LifeStint logo, `font-mono` for timers
 5. **Icon Accessibility**: All icon-only buttons must have `UTooltip`
 6. **Warm Backgrounds**: Use `bg-[#fffbf5]` not pure white for page backgrounds
 7. **Consistent Spacing**: Use the spacing scale, avoid arbitrary values

--- a/specs/009-dashboard-ui-polish/analysis-digest.json
+++ b/specs/009-dashboard-ui-polish/analysis-digest.json
@@ -1,0 +1,565 @@
+{
+  "requirements": [
+    {
+      "slug": "tab-control-uses-lightweight-treatment",
+      "type": "functional",
+      "text": "Active/inactive tab control MUST use visually lightweight treatment instead of heavy filled background",
+      "location": "spec.md:§Requirements:FR-001",
+      "measurable": true,
+      "relatedStories": ["US1"]
+    },
+    {
+      "slug": "active-row-visually-distinct-for-running-stint",
+      "type": "functional",
+      "text": "Project row with running stint MUST be visually distinguished via background, accent border, or elevation",
+      "location": "spec.md:§Requirements:FR-002",
+      "measurable": true,
+      "relatedStories": ["US1"]
+    },
+    {
+      "slug": "all-text-uses-sans-serif-except-logo",
+      "type": "functional",
+      "text": "All app text MUST use sans-serif (Instrument Sans); serif (Fraunces) reserved exclusively for logo",
+      "location": "spec.md:§Requirements:FR-003",
+      "measurable": true,
+      "relatedStories": ["US2"]
+    },
+    {
+      "slug": "timer-digits-use-tabular-figures-cohesive-unit",
+      "type": "functional",
+      "text": "Timer digits MUST use tabular/monospaced figures and display as a single cohesive unit",
+      "location": "spec.md:§Requirements:FR-004",
+      "measurable": true,
+      "relatedStories": ["US2"]
+    },
+    {
+      "slug": "muted-text-meets-wcag-aa-contrast",
+      "type": "non-functional",
+      "text": "All secondary/muted text MUST meet WCAG AA contrast (4.5:1 normal, 3:1 large) in both modes",
+      "location": "spec.md:§Requirements:FR-005",
+      "measurable": true,
+      "relatedStories": ["US3"]
+    },
+    {
+      "slug": "project-color-indicators-solid-filled-dots",
+      "type": "functional",
+      "text": "Project color indicators MUST be displayed as solid filled dots rather than hollow rings",
+      "location": "spec.md:§Requirements:FR-006",
+      "measurable": true,
+      "relatedStories": ["US3"]
+    },
+    {
+      "slug": "action-button-spacing-consistent-equal",
+      "type": "functional",
+      "text": "Action button spacing within project list rows MUST be consistent and equal across all items",
+      "location": "spec.md:§Requirements:FR-007",
+      "measurable": true,
+      "relatedStories": ["US4"]
+    },
+    {
+      "slug": "header-navigation-visually-grouped",
+      "type": "functional",
+      "text": "Header navigation items MUST be visually grouped as a cohesive navigation cluster",
+      "location": "spec.md:§Requirements:FR-008",
+      "measurable": true,
+      "relatedStories": ["US4"]
+    },
+    {
+      "slug": "secondary-labels-minimum-11px-size",
+      "type": "non-functional",
+      "text": "Secondary labels (Started, Duration, Ends) MUST be at least 11px equivalent for readability",
+      "location": "spec.md:§Requirements:FR-009",
+      "measurable": true,
+      "relatedStories": ["US2"]
+    }
+  ],
+  "userStories": [
+    {
+      "id": "US1",
+      "title": "Clear Visual Hierarchy on Dashboard",
+      "priority": "P1",
+      "scenarioCount": 3,
+      "hasAcceptanceCriteria": true,
+      "mappedRequirements": [
+        "tab-control-uses-lightweight-treatment",
+        "active-row-visually-distinct-for-running-stint"
+      ]
+    },
+    {
+      "id": "US2",
+      "title": "Readable and Consistent Typography",
+      "priority": "P2",
+      "scenarioCount": 3,
+      "hasAcceptanceCriteria": true,
+      "mappedRequirements": [
+        "all-text-uses-sans-serif-except-logo",
+        "timer-digits-use-tabular-figures-cohesive-unit",
+        "secondary-labels-minimum-11px-size"
+      ]
+    },
+    {
+      "id": "US3",
+      "title": "Accessible Color Contrast and Intentional Color Usage",
+      "priority": "P2",
+      "scenarioCount": 3,
+      "hasAcceptanceCriteria": true,
+      "mappedRequirements": [
+        "muted-text-meets-wcag-aa-contrast",
+        "project-color-indicators-solid-filled-dots"
+      ]
+    },
+    {
+      "id": "US4",
+      "title": "Balanced Spacing and Aligned Layout",
+      "priority": "P3",
+      "scenarioCount": 4,
+      "hasAcceptanceCriteria": true,
+      "mappedRequirements": [
+        "action-button-spacing-consistent-equal",
+        "header-navigation-visually-grouped"
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "id": "T001",
+      "phase": "Foundational",
+      "storyLabel": null,
+      "description": "Update --text-muted token values and add --bg-active-row token in tokens.css",
+      "files": ["app/assets/css/tokens.css"],
+      "isParallel": false,
+      "inferredRequirements": [
+        "muted-text-meets-wcag-aa-contrast",
+        "active-row-visually-distinct-for-running-stint"
+      ]
+    },
+    {
+      "id": "T002",
+      "phase": "US1",
+      "storyLabel": "US1",
+      "description": "Switch UTabs to variant=link color=neutral, remove font-serif from section heading",
+      "files": ["app/pages/dashboard.vue"],
+      "isParallel": true,
+      "inferredRequirements": [
+        "tab-control-uses-lightweight-treatment",
+        "all-text-uses-sans-serif-except-logo"
+      ]
+    },
+    {
+      "id": "T003",
+      "phase": "US1",
+      "storyLabel": "US1",
+      "description": "Add background: var(--bg-active-row) to .card-v27.state-running CSS rule",
+      "files": ["app/components/ProjectListCard.vue"],
+      "isParallel": true,
+      "inferredRequirements": [
+        "active-row-visually-distinct-for-running-stint"
+      ]
+    },
+    {
+      "id": "T004",
+      "phase": "US2",
+      "storyLabel": "US2",
+      "description": "Remove font-serif, fix timer letter-spacing, add tabular-nums, raise label to 11px",
+      "files": ["app/components/DashboardTimerHero.vue"],
+      "isParallel": true,
+      "inferredRequirements": [
+        "all-text-uses-sans-serif-except-logo",
+        "timer-digits-use-tabular-figures-cohesive-unit",
+        "secondary-labels-minimum-11px-size"
+      ]
+    },
+    {
+      "id": "T005",
+      "phase": "US2",
+      "storyLabel": "US2",
+      "description": "Remove font-serif from empty state headings in ProjectList and ArchivedProjectsList",
+      "files": [
+        "app/components/ProjectList.vue",
+        "app/components/ArchivedProjectsList.vue"
+      ],
+      "isParallel": true,
+      "inferredRequirements": [
+        "all-text-uses-sans-serif-except-logo"
+      ]
+    },
+    {
+      "id": "T006",
+      "phase": "US2",
+      "storyLabel": "US2",
+      "description": "Remove font-serif from page headings in all auth/*.vue pages (6 files)",
+      "files": [
+        "app/pages/auth/login.vue",
+        "app/pages/auth/register.vue",
+        "app/pages/auth/callback.vue",
+        "app/pages/auth/verify-email.vue",
+        "app/pages/auth/forgot-password.vue",
+        "app/pages/auth/reset-password.vue"
+      ],
+      "isParallel": true,
+      "inferredRequirements": [
+        "all-text-uses-sans-serif-except-logo"
+      ]
+    },
+    {
+      "id": "T007",
+      "phase": "US2",
+      "storyLabel": "US2",
+      "description": "Remove font-serif from headings in index.vue (~7) and legal pages",
+      "files": [
+        "app/pages/index.vue",
+        "app/pages/legal/terms.vue",
+        "app/pages/legal/privacy.vue"
+      ],
+      "isParallel": true,
+      "inferredRequirements": [
+        "all-text-uses-sans-serif-except-logo"
+      ]
+    },
+    {
+      "id": "T008",
+      "phase": "US2",
+      "storyLabel": "US2",
+      "description": "Remove font-serif from gallery.vue (~5) and component-gallery.vue layout",
+      "files": [
+        "app/pages/gallery.vue",
+        "app/layouts/component-gallery.vue"
+      ],
+      "isParallel": true,
+      "inferredRequirements": [
+        "all-text-uses-sans-serif-except-logo"
+      ]
+    },
+    {
+      "id": "T009",
+      "phase": "US2",
+      "storyLabel": "US2",
+      "description": "Update typography rules in DESIGN_SYSTEM.md (Fraunces logo-only, Instrument Sans UI)",
+      "files": ["docs/DESIGN_SYSTEM.md"],
+      "isParallel": true,
+      "inferredRequirements": [
+        "all-text-uses-sans-serif-except-logo"
+      ]
+    },
+    {
+      "id": "T010",
+      "phase": "US3",
+      "storyLabel": "US3",
+      "description": "Change project color indicators from hollow rings to solid filled dots",
+      "files": ["app/components/ProjectListCard.vue"],
+      "isParallel": false,
+      "inferredRequirements": [
+        "project-color-indicators-solid-filled-dots"
+      ]
+    },
+    {
+      "id": "T011",
+      "phase": "US4",
+      "storyLabel": "US4",
+      "description": "Standardize .card-v27 gap from 14px to 12px and padding from 14px to 12px",
+      "files": ["app/components/ProjectListCard.vue"],
+      "isParallel": false,
+      "inferredRequirements": [
+        "action-button-spacing-consistent-equal"
+      ]
+    },
+    {
+      "id": "T012",
+      "phase": "US4",
+      "storyLabel": "US4",
+      "description": "Verify navigation grouping in default.vue satisfies FR-008 (likely no-op)",
+      "files": ["app/layouts/default.vue"],
+      "isParallel": true,
+      "inferredRequirements": [
+        "header-navigation-visually-grouped"
+      ]
+    },
+    {
+      "id": "T013",
+      "phase": "Polish",
+      "storyLabel": null,
+      "description": "Verify font-serif removal completeness (grep, confirm only 9 logo instances remain)",
+      "files": [],
+      "isParallel": false,
+      "inferredRequirements": [
+        "all-text-uses-sans-serif-except-logo"
+      ]
+    },
+    {
+      "id": "T014",
+      "phase": "Polish",
+      "storyLabel": null,
+      "description": "Run lint:fix, type-check, test:run to verify no regressions",
+      "files": [],
+      "isParallel": false,
+      "inferredRequirements": []
+    },
+    {
+      "id": "T015",
+      "phase": "Polish",
+      "storyLabel": null,
+      "description": "Visual review in light+dark modes across viewports (768, 1024, 1440, 1920px)",
+      "files": [],
+      "isParallel": false,
+      "inferredRequirements": [
+        "muted-text-meets-wcag-aa-contrast",
+        "tab-control-uses-lightweight-treatment",
+        "active-row-visually-distinct-for-running-stint",
+        "all-text-uses-sans-serif-except-logo",
+        "timer-digits-use-tabular-figures-cohesive-unit",
+        "project-color-indicators-solid-filled-dots",
+        "action-button-spacing-consistent-equal",
+        "header-navigation-visually-grouped",
+        "secondary-labels-minimum-11px-size"
+      ]
+    }
+  ],
+  "architecture": {
+    "stack": [
+      "TypeScript 5",
+      "Vue 3",
+      "Nuxt 4 (SSG)",
+      "Nuxt UI 4 (Reka UI)",
+      "Tailwind CSS v4",
+      "Google Fonts (Fraunces, Instrument Sans, JetBrains Mono)",
+      "Supabase (existing, read-only for this feature)",
+      "TanStack Query (Vue Query)",
+      "Vitest"
+    ],
+    "patterns": [
+      "Three-Layer Data Access (database/schema/composable)",
+      "Three-Layer Testing Architecture",
+      "SSG + Client-Side Auth",
+      "Query Key Factory Pattern",
+      "Cache Update Strategies (optimistic + seed-and-revalidate)",
+      "Design System Token System (tokens.css)",
+      "Scoped CSS for component-specific overrides"
+    ],
+    "entities": [
+      "Project",
+      "Stint",
+      "ProjectListCard",
+      "DashboardTimerHero",
+      "UTabs",
+      "Design Tokens (--text-muted, --bg-active-row, --font-sans, --font-serif, --font-mono)"
+    ],
+    "constraints": [
+      "SSG with client-side auth (no SSR for protected routes)",
+      "WCAG AA contrast compliance (4.5:1 normal text, 3:1 large text)",
+      "Both light and dark mode support required",
+      "Tablet+ viewports only (768px-1920px per SC-006)",
+      "No new functionality - visual polish only",
+      "No database changes",
+      "No component hierarchy restructuring",
+      "Existing component structure must remain intact",
+      "Serif font (Fraunces) reserved exclusively for LifeStint logo"
+    ]
+  },
+  "constitutionRules": [
+    {
+      "principle": "I. Three-Layer Data Access Architecture",
+      "normative": "MUST",
+      "summary": "All data access MUST follow database/schema/composable three-layer pattern with type safety",
+      "checkpoints": [
+        "Export typed helpers (Row, Insert, Update)",
+        "Require TypedSupabaseClient parameter",
+        "Enforce user authentication and RLS",
+        "Return Result<T> = { data, error }",
+        "Use camelCase for API surface",
+        "Export schema limits as constants",
+        "Transform camelCase to snake_case via toDbPayload()"
+      ]
+    },
+    {
+      "principle": "II. Three-Layer Testing Architecture",
+      "normative": "MUST",
+      "summary": "Test unique logic not framework wiring: schema validation, DB integration, query key factories",
+      "checkpoints": [
+        "Layer 1: Schema tests with safeParse()",
+        "Layer 2: Database tests against local Supabase",
+        "Layer 3: Composable tests for query key factories only",
+        "Do NOT test TanStack Query hooks directly",
+        "Co-located tests with .test.ts suffix",
+        "Minimal mocking philosophy"
+      ]
+    },
+    {
+      "principle": "III. Static Site Generation (SSG) + Client-Side Auth",
+      "normative": "MUST",
+      "summary": "Public routes pre-rendered at build time; protected routes use ssr:false and client-side auth",
+      "checkpoints": [
+        "Public routes (/, /auth/*) pre-rendered",
+        "Protected routes use ssr: false",
+        "Auth middleware client-only (import.meta.server guard)",
+        "Only anon keys in .env (embedded at build time)",
+        "Never commit service role keys"
+      ]
+    },
+    {
+      "principle": "IV. Type Safety & Code Generation",
+      "normative": "MUST",
+      "summary": "Type safety enforced via generated types, TypedSupabaseClient, Zod schemas at all levels",
+      "checkpoints": [
+        "Generated types from Supabase schema",
+        "Use useTypedSupabaseClient() not useSupabaseClient()",
+        "Zod schemas for runtime validation",
+        "Each layer exports own types",
+        "Run supabase:types after schema changes"
+      ]
+    },
+    {
+      "principle": "V. User-Friendly Error Handling",
+      "normative": "MUST",
+      "summary": "Three-layer error propagation: DB translates errors, composables validate, components toast",
+      "checkpoints": [
+        "Database layer translates PostgreSQL errors",
+        "Composable layer validates with Zod and throws",
+        "Component layer uses try-catch with toast.add()",
+        "Best-effort for non-critical operations (log, don't block)"
+      ]
+    },
+    {
+      "principle": "VI. Cache Update Strategies",
+      "normative": "MUST",
+      "summary": "Mutations MUST use optimistic update OR seed-and-revalidate; never leave cache inconsistent",
+      "checkpoints": [
+        "Optimistic: onMutate snapshot, onError restore, onSettled invalidate",
+        "Seed-and-revalidate: onSuccess setQueryData then invalidateQueries",
+        "Choose pattern based on operation reliability profile",
+        "Never leave cache in inconsistent state"
+      ]
+    },
+    {
+      "principle": "VII. Query Key Factory Pattern",
+      "normative": "MUST",
+      "summary": "Cache organization MUST use centralized key factories with all/lists/list/detail hierarchy",
+      "checkpoints": [
+        "Centralized key factories per entity",
+        "Hierarchical keys: all > lists > list(filters) > detail(id)",
+        "Full key match required for getQueryData()",
+        "Broad/targeted/multiple invalidation strategies"
+      ]
+    },
+    {
+      "principle": "VIII. Observability & Logging",
+      "normative": "MUST",
+      "summary": "All app code MUST use logger/createLogger utilities instead of raw console.* calls",
+      "checkpoints": [
+        "Use logger from ~/utils/logger",
+        "Use createLogger(module) for domain-specific tracing",
+        "Logs route to Sentry in production via createConsolaReporter()",
+        "Edge Functions exception: use console.* directly"
+      ]
+    },
+    {
+      "principle": "Component Library & Styling",
+      "normative": "MUST",
+      "summary": "Nuxt UI 4 (Reka UI) with Tailwind CSS v4; always provide dark mode variants; follow DESIGN_SYSTEM.md",
+      "checkpoints": [
+        "Nuxt UI 4 built on Reka UI (NOT Radix)",
+        "Tailwind CSS v4 via @theme directive",
+        "Always provide dark:* variants",
+        "Follow docs/DESIGN_SYSTEM.md for all styling",
+        "Check Nuxt UI 4 docs via Context7 before modifying components"
+      ]
+    },
+    {
+      "principle": "Code Quality",
+      "normative": "MUST",
+      "summary": "ESLint via @nuxt/eslint, run lint:fix before commit, no comments unless complex logic",
+      "checkpoints": [
+        "ESLint configured via @nuxt/eslint",
+        "Run lint:fix before committing",
+        "camelCase for API, snake_case for database",
+        "No comments unless logic is too complex"
+      ]
+    },
+    {
+      "principle": "Design System Compliance",
+      "normative": "MUST",
+      "summary": "ALL styling MUST follow docs/DESIGN_SYSTEM.md tokens, typography, spacing, and patterns",
+      "checkpoints": [
+        "Use documented color tokens (brand, ink, mint, amberx)",
+        "Follow typography scale and font families",
+        "Use Nuxt UI components with documented patterns",
+        "Apply spacing, layout, and animation guidelines",
+        "No custom styling deviating from design system without justification"
+      ]
+    }
+  ],
+  "terminology": [
+    {
+      "term": "stint",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md", "constitution.md"],
+      "variants": ["stint", "session", "work session", "focused work session"]
+    },
+    {
+      "term": "project",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md", "constitution.md"],
+      "variants": ["project", "client project"]
+    },
+    {
+      "term": "active row",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md"],
+      "variants": ["active row", "active project row", "running row", "state-running"]
+    },
+    {
+      "term": "token",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md", "constitution.md"],
+      "variants": ["token", "design token", "CSS token", "color token"]
+    },
+    {
+      "term": "muted text",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md"],
+      "variants": ["muted text", "secondary text", "--text-muted", "secondary/muted text"]
+    },
+    {
+      "term": "WCAG AA",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md"],
+      "variants": ["WCAG AA", "WCAG AA contrast", "4.5:1 contrast ratio", "accessibility contrast"]
+    },
+    {
+      "term": "font-serif",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md"],
+      "variants": ["font-serif", "serif", "Fraunces", "serif font"]
+    },
+    {
+      "term": "font-sans",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md"],
+      "variants": ["font-sans", "sans-serif", "Instrument Sans", "sans-serif font"]
+    },
+    {
+      "term": "tabular-nums",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md"],
+      "variants": ["tabular-nums", "tabular figures", "monospaced figures", "font-variant-numeric: tabular-nums"]
+    },
+    {
+      "term": "color indicator",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md"],
+      "variants": ["color indicator", "project color indicator", "color dot", "hollow ring", "solid dot"]
+    },
+    {
+      "term": "ProjectListCard",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md"],
+      "variants": ["ProjectListCard", "ProjectListCard.vue", "project list card", ".card-v27"]
+    },
+    {
+      "term": "DashboardTimerHero",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md"],
+      "variants": ["DashboardTimerHero", "DashboardTimerHero.vue", "timer card", "timer hero"]
+    },
+    {
+      "term": "UTabs",
+      "usageLocations": ["spec.md", "plan.md", "tasks.md"],
+      "variants": ["UTabs", "tab control", "active/inactive tab", "segmented control"]
+    }
+  ],
+  "metrics": {
+    "totalRequirements": 9,
+    "totalStories": 4,
+    "totalTasks": 15,
+    "totalPhases": 7,
+    "totalEdgeCases": 4,
+    "totalPrinciples": 11
+  }
+}

--- a/specs/009-dashboard-ui-polish/checklists/requirements.md
+++ b/specs/009-dashboard-ui-polish/checklists/requirements.md
@@ -1,0 +1,46 @@
+# Specification Quality Checklist: Dashboard UI Polish
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Design System Alignment
+
+- [x] All requirements mapped to existing design tokens
+- [x] Token gaps identified (new: `--bg-active-row`)
+- [x] Token value issues identified (`--text-muted` dark mode fails WCAG AA at ~3.7:1)
+- [x] Non-standard values flagged for standardization (`gap: 14px` → scale value)
+- [x] Font token usage validated (`--font-serif` vs `--font-sans` in timer card)
+
+## Notes
+
+- All items passed on first validation pass
+- Spec covers 4 user stories mapped to the 4 review categories from issue #104 (hierarchy, typography, color, spacing)
+- 9 functional requirements, 6 success criteria, 4 edge cases identified
+- No clarification needed — the issue provided detailed, actionable feedback
+- Design token audit added: 1 token value change, 1 new token, several CSS-level adjustments

--- a/specs/009-dashboard-ui-polish/data-model.md
+++ b/specs/009-dashboard-ui-polish/data-model.md
@@ -1,0 +1,91 @@
+# Data Model: Dashboard UI Polish
+
+**Feature Branch**: `009-dashboard-ui-polish`
+**Date**: 2026-02-24
+
+> This feature has no database entity changes. The "data model" for a visual polish feature is the **CSS design token system** — the tokens that components consume to render consistently.
+
+## Token Changes
+
+### Modified Tokens
+
+#### `--text-muted` (value adjustment, both modes)
+
+| Property | Light Mode | Dark Mode |
+|----------|-----------|-----------|
+| **Current** | `#a8a29e` (~2.4:1 vs `--bg-primary`) | `#78716c` (~3.7:1 vs `--bg-primary`) |
+| **Proposed** | `#736b66` (~5.0:1 vs `--bg-primary`) | `#908984` (~5.2:1 vs `--bg-primary`) |
+| **WCAG AA** | 4.5:1 minimum | 4.5:1 minimum |
+| **Headroom** | ~0.5:1 buffer | ~0.7:1 buffer |
+
+**Consumers**: Every component using `color: var(--text-muted)` or `text-[var(--text-muted)]`. Includes timestamps, metadata labels, secondary descriptions, inactive icons.
+
+**Validation**: Run contrast checker against `--bg-primary`, `--bg-secondary`, `--bg-card` backgrounds in both modes. All combinations must meet 4.5:1.
+
+### New Tokens
+
+#### `--bg-active-row`
+
+| Property | Light Mode | Dark Mode |
+|----------|-----------|-----------|
+| **Value** | `rgba(22, 163, 74, 0.05)` | `rgba(34, 197, 94, 0.08)` |
+| **Visual** | Very subtle green wash | Subtle green wash on dark surface |
+| **Contrast** | Decorative only, no text contrast requirement | Decorative only |
+
+**Consumer**: `ProjectListCard.vue` — applied to `.card-v27.state-running` only. Paused stints (`.state-paused`) retain amber treatment.
+
+**Relationship**: Complements existing `--accent-secondary` (green) for the running-stint visual language.
+
+## Component-Level Style Changes
+
+### ProjectListCard.vue
+
+| Element | Current | Target | Requirement |
+|---------|---------|--------|-------------|
+| `.card-v27` gap | `14px` (non-standard) | `12px` (`gap-3`) | FR-007 |
+| `.card-v27.state-running` background | None (green shadow only) | `var(--bg-active-row)` | FR-002 |
+| `.project-color` shape | Hollow ring (`border: 3.5px`, `bg: transparent`) | Solid dot (`bg: color`, no border) | FR-006 |
+| `.project-color` size | `18px` | `12px` (proportional to solid) | FR-006 |
+
+### DashboardTimerHero.vue
+
+| Element | Current | Target | Requirement |
+|---------|---------|--------|-------------|
+| `.session-project` font | `font-serif` (Fraunces) | Inherit sans-serif (Instrument Sans) | FR-003 |
+| `.timer-display` letter-spacing | `0.02em` | `0` (remove property) | FR-004 |
+| `.meta-label` font-size (mobile) | `10px` | `11px` | FR-009 |
+
+### dashboard.vue
+
+| Element | Current | Target | Requirement |
+|---------|---------|--------|-------------|
+| "Your Projects" heading font | `font-serif` (Fraunces) | Remove `font-serif` class | FR-003 |
+| `UTabs` variant | Default (`pill`) | `variant="link"` `color="neutral"` | FR-001 |
+
+### System-Wide Typography
+
+| Scope | Current | Target | Requirement |
+|-------|---------|--------|-------------|
+| ~30 non-logo `font-serif` instances | Fraunces serif font | Remove class → inherit Instrument Sans | FR-003 |
+| 9 logo instances | Fraunces serif font | **Keep unchanged** | FR-003 |
+
+## State Transitions
+
+No new state transitions. Existing project card states remain:
+
+```
+state-running  → green treatment (enhanced with --bg-active-row)
+state-paused   → amber treatment (unchanged)
+state-inactive → muted treatment (unchanged)
+(default)      → base card style (unchanged)
+```
+
+## Validation Rules
+
+| Rule | Source | Check |
+|------|--------|-------|
+| All `--text-muted` usage meets WCAG AA 4.5:1 | FR-005, SC-002 | Contrast checker against all background tokens |
+| `font-serif` appears only on logo elements | FR-003, SC-004 | Grep for `font-serif` in templates, verify each is a logo |
+| `--bg-active-row` applied only to running (not paused) rows | FR-002, Clarification | Check `.state-running` selector, not `.state-paused` |
+| Timer digits have no positive letter-spacing | FR-004 | Inspect `.timer-display` computed styles |
+| Project color indicators are solid, not hollow | FR-006, SC-003 | Visual inspection — no visible border-only rendering |

--- a/specs/009-dashboard-ui-polish/plan.md
+++ b/specs/009-dashboard-ui-polish/plan.md
@@ -1,0 +1,146 @@
+# Implementation Plan: Dashboard UI Polish
+
+**Branch**: `009-dashboard-ui-polish` | **Date**: 2026-02-24 | **Spec**: `specs/009-dashboard-ui-polish/spec.md`
+**Input**: Feature specification from `/specs/009-dashboard-ui-polish/spec.md`
+
+## Summary
+
+Visual hierarchy, typography, color/contrast, and spacing refinements for the LifeStint dashboard. This is a pure visual polish pass: no new functionality, no database changes, no API changes. The work involves CSS token adjustments, Nuxt UI prop changes, class removals/additions across ~15 files, and design system documentation updates to achieve WCAG AA compliance and improved visual clarity.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 / Vue 3 / Nuxt 4
+**Primary Dependencies**: Nuxt UI 4 (Reka UI), Tailwind CSS v4, Google Fonts (Fraunces, Instrument Sans)
+**Storage**: N/A — no database changes
+**Testing**: Vitest (lint, type-check, existing tests); visual inspection for CSS changes
+**Target Platform**: Web (SSG), tablet+ viewports (768px–1920px per SC-006)
+**Project Type**: Web (Nuxt SSG)
+**Performance Goals**: N/A — visual-only changes, no runtime impact
+**Constraints**: WCAG AA contrast (4.5:1 normal text, 3:1 large text), both light and dark modes
+**Scale/Scope**: ~15 files modified, ~30 `font-serif` class removals, 2 token value changes, 1 new token, ~8 component CSS adjustments
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Applicable? | Status | Notes |
+|-----------|------------|--------|-------|
+| I. Three-Layer Data Access | No | PASS | No data layer changes |
+| II. Three-Layer Testing | Minimal | PASS | No new business logic; existing tests run for regression |
+| III. SSG + Client-Side Auth | No | PASS | No route or auth changes |
+| IV. Type Safety & Code Generation | No | PASS | No type changes |
+| V. User-Friendly Error Handling | No | PASS | No error handling changes |
+| VI. Cache Update Strategies | No | PASS | No mutation changes |
+| VII. Query Key Factory Pattern | No | PASS | No cache key changes |
+| VIII. Observability & Logging | No | PASS | No logging changes |
+| Component Library & Styling | **Yes** | PASS | All changes follow design system; tokens.css pattern followed; dark mode variants provided; Nuxt UI docs checked for UTabs API |
+| Code Quality | **Yes** | PASS | Will lint before commit; no comments added |
+| Design System Compliance | **Yes** | PASS | DESIGN_SYSTEM.md updated to reflect new typography rules |
+
+**Post-Phase 1 Re-check**: All principles still pass. No architectural deviations introduced. The UTabs variant change uses the built-in Nuxt UI API (`variant="link"`, `color="neutral"`), no custom workarounds.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-dashboard-ui-polish/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — decisions, risks, contrast calculations
+├── data-model.md        # Phase 1 output — token changes, component style map
+├── quickstart.md        # Phase 1 output — 9-step implementation guide
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (files to modify)
+
+```text
+app/
+├── assets/css/
+│   └── tokens.css                    # Token value changes (--text-muted, --bg-active-row)
+├── components/
+│   ├── ProjectListCard.vue           # Active row bg, solid dots, card gap, button spacing
+│   ├── DashboardTimerHero.vue        # Timer letter-spacing, label size, font-serif removal
+│   ├── ProjectList.vue               # font-serif removal (empty states)
+│   └── ArchivedProjectsList.vue      # font-serif removal (empty state)
+├── pages/
+│   ├── dashboard.vue                 # UTabs variant, font-serif removal
+│   ├── index.vue                     # font-serif removal (7 headings)
+│   ├── gallery.vue                   # font-serif removal (5 headings, dev tool)
+│   ├── auth/
+│   │   ├── login.vue                 # font-serif removal
+│   │   ├── register.vue              # font-serif removal
+│   │   ├── callback.vue              # font-serif removal (3 headings)
+│   │   ├── verify-email.vue          # font-serif removal
+│   │   ├── forgot-password.vue       # font-serif removal
+│   │   └── reset-password.vue        # font-serif removal
+│   └── legal/
+│       ├── terms.vue                 # font-serif removal
+│       └── privacy.vue               # font-serif removal
+├── layouts/
+│   └── component-gallery.vue         # font-serif removal (dev tool)
+docs/
+└── DESIGN_SYSTEM.md                  # Typography rules update
+```
+
+**Structure Decision**: No new files or directories created (aside from spec artifacts). All changes are modifications to existing files.
+
+## Complexity Tracking
+
+No constitution violations. All changes use existing patterns:
+- Token system for colors
+- Nuxt UI props for component variants
+- Tailwind utility classes for styling
+- Scoped CSS for component-specific overrides
+
+## Critical Path
+
+**Longest Chain**: 2 steps (Step 1 → any of Steps 3–9)
+
+| Step | Description | Blocks |
+|------|-------------|--------|
+| 1 | Token updates (`--text-muted` values, `--bg-active-row`) | Steps 5 (active row bg depends on new token) |
+| 2 | Design system docs | Nothing (independent) |
+| 3 | Typography: remove `font-serif` from non-logo elements | Nothing |
+| 4 | UTabs lightweight variant | Nothing |
+| 5 | Active row background | Nothing |
+| 6 | Timer digit cohesion | Nothing |
+| 7 | Solid project color dots | Nothing |
+| 8 | Button spacing & card gap | Nothing |
+| 9 | Label size & navigation verification | Nothing |
+
+**Bottleneck Steps** (blocks 3+ downstream steps):
+- Step 1 is the only bottleneck — it provides the token values consumed by Step 5 (directly) and improves muted text rendering for all visual steps. However, the dependency is soft for most steps (Steps 3, 4, 6–9 don't strictly require Step 1 to be complete first).
+
+**Conclusion**: This is a shallow-dependency feature. After Step 1, all remaining steps can be executed in any order or in parallel.
+
+## Testing Approach
+
+| Component | Verification Method | Success Criteria |
+|-----------|-------------------|------------------|
+| `--text-muted` contrast (FR-005) | Browser contrast checker tool | ≥4.5:1 ratio against all bg tokens in both modes |
+| Active row background (FR-002) | Visual inspection with active stint | Running row visually distinct; paused row unchanged |
+| Typography system (FR-003) | `grep -r "font-serif" app/` | Only 9 logo instances remain |
+| UTabs variant (FR-001) | Visual inspection | Lightweight text/underline treatment, no heavy pill |
+| Timer digits (FR-004) | Visual inspection | Digits + colons as single cohesive unit |
+| Color indicators (FR-006) | Visual inspection | Solid dots, not hollow rings |
+| Button spacing (FR-007) | DevTools measurement | Uniform gaps across all project rows |
+| Navigation grouping (FR-008) | Visual inspection | Items appear as cohesive group |
+| Label size (FR-009) | DevTools computed styles | ≥11px on mobile |
+| Regression | `npm run lint && npm run type-check && npm run test:run` | All pass |
+| Cross-mode | Browse all pages in light + dark mode | No visual regressions |
+| Viewport range (SC-006) | Test at 768px, 1024px, 1440px, 1920px | Layout and spacing correct at all widths |
+
+**Testing strategy is primarily visual** — this is a CSS/template polish feature. Automated tests catch regressions in lint, types, and existing business logic, but the success criteria (SC-001 through SC-006) are visual and measured by inspection.
+
+## Delivery Strategy
+
+**MVP Boundary**: N/A — atomic feature. All 9 requirements work together to create a cohesive visual improvement. Delivering a subset (e.g., only typography without contrast fixes) would create an inconsistent intermediate state.
+
+**However**, if incremental delivery is preferred, the natural slices are:
+
+1. **Slice 1 — Foundations**: Steps 1–2 (tokens + docs) — lays groundwork, no visual regressions
+2. **Slice 2 — High-Impact Visual**: Steps 3–5 (typography, tabs, active row) — addresses P1 + P2 requirements
+3. **Slice 3 — Polish Details**: Steps 6–9 (timer, dots, spacing, labels) — addresses P2 + P3 requirements
+
+**Recommended**: Deliver as a single PR since all changes are low-risk, non-breaking CSS/template modifications with no data or API implications.

--- a/specs/009-dashboard-ui-polish/quickstart.md
+++ b/specs/009-dashboard-ui-polish/quickstart.md
@@ -1,0 +1,271 @@
+# Quickstart: Dashboard UI Polish
+
+**Feature Branch**: `009-dashboard-ui-polish`
+**Date**: 2026-02-24
+
+> Step-by-step implementation guide. Each step is atomic and verifiable.
+
+## Prerequisites
+
+- Branch `009-dashboard-ui-polish` checked out
+- Local dev server available (`npm run dev` on port 3005)
+- Browser with DevTools for contrast/style inspection
+
+---
+
+## Step 1: Update Design Tokens
+
+**File**: `app/assets/css/tokens.css`
+
+### 1a. Adjust `--text-muted` for WCAG AA compliance
+
+**Light mode** (~line 33): Change `#a8a29e` → `#736b66`
+**Dark mode** (~line 66): Change `#78716c` → `#908984`
+
+### 1b. Add `--bg-active-row` token
+
+Add to light mode block (after `--bg-card`):
+```css
+--bg-active-row: rgba(22, 163, 74, 0.05);
+```
+
+Add to dark mode block (after `--bg-card`):
+```css
+--bg-active-row: rgba(34, 197, 94, 0.08);
+```
+
+### Verification
+- Open dashboard in both light and dark mode
+- Muted text should be visibly more readable but still secondary
+- Use browser contrast checker extension to verify ≥4.5:1 against `--bg-primary`, `--bg-secondary`, and `--bg-card`
+
+---
+
+## Step 2: Update Design System Documentation
+
+**File**: `docs/DESIGN_SYSTEM.md`
+
+Update the typography section to reflect:
+- **Fraunces** (`--font-serif`): Reserved exclusively for the LifeStint logo wordmark
+- **Instrument Sans** (`--font-sans`): All headings, titles, labels, body text, and UI elements
+- **JetBrains Mono** (`--font-mono`): Timer displays, numerical values, code
+
+Remove or update any references to Fraunces being used for "headings, display text."
+
+### Verification
+- Read the updated doc and confirm it matches the new typography rules
+- No code changes needed for this step
+
+---
+
+## Step 3: System-Wide Typography — Remove `font-serif` from Non-Logo Elements
+
+**Scope**: ~30 instances across ~15 files. Remove the `font-serif` class from all non-logo elements. Logo instances (9 total) must be preserved.
+
+### Dashboard & Components
+| File | Line | Element | Action |
+|------|------|---------|--------|
+| `app/pages/dashboard.vue` | ~227 | "Your Projects" h2 | Remove `font-serif` |
+| `app/components/DashboardTimerHero.vue` | ~130 | `.session-project` h2 | Remove `font-serif` |
+| `app/components/ProjectList.vue` | ~503, ~529, ~556 | Empty state h3 headings | Remove `font-serif` |
+| `app/components/ArchivedProjectsList.vue` | ~103 | Empty state h3 | Remove `font-serif` |
+
+### Auth Pages
+| File | Line | Element | Action |
+|------|------|---------|--------|
+| `app/pages/auth/login.vue` | ~107 | "Welcome back" h2 | Remove `font-serif` |
+| `app/pages/auth/register.vue` | ~177 | "Create your account" h2 | Remove `font-serif` |
+| `app/pages/auth/callback.vue` | ~122, ~138, ~170 | Status h2 headings | Remove `font-serif` |
+| `app/pages/auth/verify-email.vue` | ~16 | "Check your email" h2 | Remove `font-serif` |
+| `app/pages/auth/forgot-password.vue` | ~16 | "Reset your password" h2 | Remove `font-serif` |
+| `app/pages/auth/reset-password.vue` | ~16 | "Set your new password" h2 | Remove `font-serif` |
+
+### Public Pages
+| File | Line | Element | Action |
+|------|------|---------|--------|
+| `app/pages/index.vue` | ~156 | Hero h1 | Remove `font-serif` |
+| `app/pages/index.vue` | ~336, ~504 | Section h2 headings | Remove `font-serif` |
+| `app/pages/index.vue` | ~801, ~993, ~1022, ~1266 | Feature/CTA/Pricing/FAQ h3 | Remove `font-serif` |
+| `app/pages/legal/terms.vue` | ~31 | Page title h1 | Remove `font-serif` |
+| `app/pages/legal/privacy.vue` | ~31 | Page title h1 | Remove `font-serif` |
+
+### Dev Tools (Gallery)
+| File | Line | Element | Action |
+|------|------|---------|--------|
+| `app/pages/gallery.vue` | ~174, ~257, ~334, ~400, ~440 | Section headings | Remove `font-serif` |
+| `app/layouts/component-gallery.vue` | ~27 | Layout title | Remove `font-serif` |
+
+### Verification
+- Run `grep -r "font-serif" app/` — only logo instances should remain (9 occurrences)
+- Browse dashboard, auth pages, and marketing page — all headings should render in Instrument Sans
+- Logo "LifeStint" text should still be in Fraunces
+
+---
+
+## Step 4: Lightweight Tab Control (FR-001)
+
+**File**: `app/pages/dashboard.vue`
+
+Change the `UTabs` component to use a lightweight variant:
+
+```vue
+<UTabs
+  v-if="!isLoading"
+  v-model="selectedTab"
+  :items="tabItems"
+  variant="link"
+  color="neutral"
+  class="w-full"
+>
+```
+
+### Verification
+- Dashboard tabs should show as text-only with an underline indicator
+- No heavy filled pill background
+- Active tab text should be highlighted, inactive tabs should be muted
+- Tab switching should still work correctly
+
+---
+
+## Step 5: Active Row Background (FR-002)
+
+**File**: `app/components/ProjectListCard.vue`
+
+Add background to `.card-v27.state-running` CSS rule (~line 321):
+
+```css
+.card-v27.state-running {
+  background: var(--bg-active-row);
+  box-shadow: 0 2px 12px rgba(22, 163, 74, 0.1);
+}
+```
+
+### Verification
+- Start a stint on any project
+- The running project's card should have a very subtle green-tinted background
+- Paused projects should retain their amber treatment (no green background)
+- Projects without active stints should have the default card background
+
+---
+
+## Step 6: Timer Digit Cohesion (FR-004)
+
+**File**: `app/components/DashboardTimerHero.vue`
+
+In the `.timer-display` CSS rule (~line 359):
+- Remove `letter-spacing: 0.02em` (or set to `0`)
+- Ensure `font-variant-numeric: tabular-nums` is set (may already be applied via Tailwind class)
+
+```css
+.timer-display {
+  font-family: var(--font-mono);
+  font-size: 48px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 0 40px var(--accent-primary-glow);
+}
+```
+
+### Verification
+- Timer digits should appear as a tight, cohesive unit
+- Colons should sit close to adjacent digits, not float with extra space
+- Digits should not shift when values change (tabular-nums ensures fixed widths)
+
+---
+
+## Step 7: Solid Project Color Dots (FR-006)
+
+**File**: `app/components/ProjectListCard.vue`
+
+### 7a. Update CSS (~line 377)
+
+Change from hollow ring to solid dot:
+```css
+.project-color {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+```
+
+Remove `background: transparent`, `border-width: 3.5px`, `border-style: solid`.
+
+### 7b. Update template class bindings
+
+Change the computed color classes from `border-*` to `bg-*` variants. For example:
+- `border-red-500` → `bg-red-500`
+- `border-green-500` → `bg-green-500`
+- etc.
+
+Update the `projectColorClass` computed (or equivalent) to use `bg-` prefixed classes instead of `border-` prefixed classes.
+
+### Verification
+- Project list should show solid filled dots instead of hollow rings
+- Dots should look clearly decorative, not interactive
+- All project colors should render correctly (blue, red, green, yellow, gray, etc.)
+
+---
+
+## Step 8: Button Spacing & Card Gap (FR-007)
+
+**File**: `app/components/ProjectListCard.vue`
+
+### 8a. Standardize card gap (~line 304)
+
+Change `.card-v27` from `gap: 14px` to `gap: 12px`.
+
+### 8b. Standardize card padding (~line 305)
+
+Change `.card-v27` from `padding: 14px 20px` to `padding: 12px 20px` (align vertical padding with gap).
+
+### Verification
+- All project cards should have uniform spacing between elements
+- Action buttons (edit, play/pause, stop) should have consistent gaps
+- Compare spacing visually across multiple project rows — should be identical
+
+---
+
+## Step 9: Label Minimum Size & Navigation (FR-008, FR-009)
+
+**File**: `app/components/DashboardTimerHero.vue`
+
+### 9a. Raise meta-label minimum size (FR-009)
+
+Change `.meta-label` mobile font-size from `10px` to `11px` (~line 336):
+```css
+.meta-label {
+  font-size: 11px;
+  /* ... rest unchanged */
+}
+```
+
+### 9b. Navigation grouping verification (FR-008)
+
+**File**: `app/layouts/default.vue`
+
+The navigation already uses a cohesive pill container with `bg-[#fef7ed] dark:bg-[#1f1b18] p-1 rounded-full gap-1`. Verify this looks correctly grouped. **May be a no-op** — existing implementation already satisfies FR-008.
+
+### Verification
+- "Started", "Duration", "Ends" labels should be readable on mobile at 11px
+- Navigation items in header should appear as a visually cohesive group
+- No elements should appear to float independently
+
+---
+
+## Final Verification Checklist
+
+After all steps are complete:
+
+- [ ] **SC-001**: Active project identifiable within 3 seconds (green background + visual distinction)
+- [ ] **SC-002**: All text meets WCAG AA in both modes (contrast checker on muted text)
+- [ ] **SC-003**: Color indicators look decorative, not interactive (solid dots, not rings)
+- [ ] **SC-004**: Exactly 3 font families with clear roles (serif=logo, sans=UI, mono=timer)
+- [ ] **SC-005**: Action button gaps uniform across all project cards (visual inspection)
+- [ ] **SC-006**: Renders correctly 768px–1920px (test at tablet and desktop breakpoints)
+- [ ] Run `npm run lint:fix` to clean up any formatting
+- [ ] Run `npm run type-check` to verify no TypeScript issues
+- [ ] Run `npm run test:run` to verify no test regressions
+- [ ] Visual review in both light and dark mode

--- a/specs/009-dashboard-ui-polish/research.md
+++ b/specs/009-dashboard-ui-polish/research.md
@@ -1,0 +1,172 @@
+# Research: Dashboard UI Polish
+
+**Feature Branch**: `009-dashboard-ui-polish`
+**Date**: 2026-02-24
+
+## Architectural Fit
+
+### Existing Patterns to Follow
+
+1. **CSS Token System** (`app/assets/css/tokens.css`): All color values use CSS custom properties with light/dark mode variants via `:root` and `:root.dark` selectors. New tokens (`--bg-active-row`) must follow this pattern.
+
+2. **Tailwind v4 `@theme` Directive** (`app/assets/css/main.css`): Font families are registered in both the `@theme` block (for Tailwind utilities) and `tokens.css` `:root` (for `var()` usage). The `@theme` block is the single source for Tailwind config — no `tailwind.config.ts` exists.
+
+3. **Scoped Component Styles**: Dashboard components (`ProjectListCard.vue`, `DashboardTimerHero.vue`) use `<style scoped>` with CSS custom properties from `tokens.css`. State variants are applied via conditional `:class` bindings and scoped CSS selectors (`.card-v27.state-running`, `.timer-display.is-paused`).
+
+4. **Nuxt UI `:ui` Prop Pattern**: Components like `UNavigationMenu` in `default.vue` already use the `:ui` prop for deep style customization. The same pattern applies to `UTabs`.
+
+### New Patterns Needed
+
+None. All changes fit within existing patterns: token value adjustments, class removals, and Nuxt UI prop changes.
+
+## Decision Log
+
+### D-001: WCAG AA Compliant `--text-muted` Values
+
+**Decision**: Adjust `--text-muted` to warm stone tones that meet 4.5:1 minimum contrast.
+
+**Current values and failures**:
+| Mode | Background | Current Muted | Contrast | Status |
+|------|-----------|--------------|----------|--------|
+| Light | `#fffbf5` (L=0.969) | `#a8a29e` (L=0.370) | ~2.4:1 | FAIL |
+| Dark | `#1c1917` (L=0.010) | `#78716c` (L=0.171) | ~3.7:1 | FAIL |
+
+**Recommended values** (verify with contrast checker during implementation):
+| Mode | Recommended Muted | Expected Contrast | Notes |
+|------|------------------|-------------------|-------|
+| Light | `#736b66` (darker stone) | ~5.0:1 | Warm tone, matches design palette |
+| Dark | `#908984` (lighter stone) | ~5.2:1 | Warm tone, sufficient headroom above 4.5:1 |
+
+**Rationale**: Values chosen with ~0.5:1 headroom above minimum to account for sub-pixel rendering variations across browsers and displays. Both values maintain the warm stone palette established in the design system.
+
+**Alternatives considered**:
+- Using Tailwind's standard Stone scale values directly → Rejected because Stone-500 (#78716c) fails in dark mode and Stone-400 (#a8a29e) fails in light mode
+- Per-component overrides instead of token change → Rejected because the token is used consistently and a single change is cleaner
+
+### D-002: Active Row Background Token
+
+**Decision**: Create `--bg-active-row` using green-tinted translucent backgrounds.
+
+**Recommended values**:
+| Mode | Value | Visual Effect |
+|------|-------|--------------|
+| Light | `rgba(22, 163, 74, 0.05)` | Very subtle green wash |
+| Dark | `rgba(34, 197, 94, 0.08)` | Subtle green wash on dark card surface |
+
+**Rationale**: Green aligns with the existing running-stint visual language (green text, green shadow). The opacity is kept very low to avoid overwhelming the row content — it should be a subtle background shift, not a strong highlight. Paused stints retain their amber treatment unchanged.
+
+**Alternatives considered**:
+- Terracotta/brand accent tint → Rejected because running stints already use green throughout the UI (text color, header pill, shadow)
+- Solid background color → Rejected because translucent values work better with the existing `backdrop-filter: blur()` card aesthetic
+- Left border accent only → Considered viable but less discoverable than background; could be added as enhancement
+
+### D-003: Tab Control Variant
+
+**Decision**: Switch `UTabs` from default `variant="pill"` to `variant="link"` with `color="neutral"`.
+
+**Rationale**: Nuxt UI 4's "link" variant renders tab triggers as plain text with an underline indicator, which is visually lightweight. The "neutral" color prevents the accent color from competing with the project list. This matches FR-001's requirement exactly.
+
+**Alternatives considered**:
+- Custom `:ui` prop on the default pill variant → More complex, harder to maintain
+- Replacing UTabs with custom tab component → Over-engineering; the built-in variant solves the problem
+
+### D-004: Typography System-Wide Change
+
+**Decision**: Remove `font-serif` class from all non-logo elements. Keep serif exclusively on 9 logo instances across 7 files.
+
+**Files requiring `font-serif` removal** (non-logo text):
+| File | Count | Elements |
+|------|-------|----------|
+| `app/pages/index.vue` | 7 | Hero headline, section headings, CTA, pricing, FAQ |
+| `app/pages/dashboard.vue` | 1 | "Your Projects" section title |
+| `app/pages/auth/login.vue` | 1 | "Welcome back" heading |
+| `app/pages/auth/register.vue` | 1 | "Create your account" heading |
+| `app/pages/auth/callback.vue` | 3 | Status headings |
+| `app/pages/auth/verify-email.vue` | 1 | "Check your email" heading |
+| `app/pages/auth/forgot-password.vue` | 1 | "Reset your password" heading |
+| `app/pages/auth/reset-password.vue` | 1 | "Set your new password" heading |
+| `app/pages/legal/terms.vue` | 1 | Page title |
+| `app/pages/legal/privacy.vue` | 1 | Page title |
+| `app/components/DashboardTimerHero.vue` | 1 | Active session project name |
+| `app/components/ProjectList.vue` | 3 | Empty state headings |
+| `app/components/ArchivedProjectsList.vue` | 1 | Empty state heading |
+| `app/pages/gallery.vue` | 5 | Section headings (dev tool) |
+| `app/layouts/component-gallery.vue` | 1 | Layout title (dev tool) |
+| **Total** | **~30** | |
+
+**Logo instances to KEEP** (9 across 7 files):
+- `app/layouts/default.vue:87` — Navbar logo
+- `app/pages/index.vue:83,1345` — Marketing navbar + footer
+- `app/pages/legal/terms.vue:21,133` — Navbar + footer
+- `app/pages/legal/privacy.vue:21,113` — Navbar + footer
+- `app/pages/auth/login.vue:102` — Auth card logo
+- `app/pages/auth/register.vue:172` — Auth card logo
+
+**Rationale**: Simpler to remove `font-serif` from the ~30 non-logo instances than to refactor all headings to use a different class. The sans-serif font (Instrument Sans) inherits naturally when `font-serif` is removed since it's the default via `@theme`.
+
+### D-005: Timer Digit Cohesion
+
+**Decision**: Remove positive `letter-spacing: 0.02em` from `.timer-display` and ensure `font-variant-numeric: tabular-nums` is applied.
+
+**Current state** (`DashboardTimerHero.vue:359`):
+```css
+.timer-display {
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;  /* Remove this */
+}
+```
+
+**Target**: `letter-spacing: 0` (or remove the property entirely). The monospace font (JetBrains Mono) already provides consistent character widths; adding positive spacing separates colons from digits.
+
+### D-006: Project Color Indicators
+
+**Decision**: Change from hollow rings to solid filled dots by swapping `background: transparent` + `border-width: 3.5px` to `background: <color>` + `border: none`.
+
+**Current state** (`ProjectListCard.vue:377-385`):
+```css
+.project-color {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: transparent;    /* → change to project color */
+  border-width: 3.5px;        /* → remove */
+  border-style: solid;        /* → remove */
+}
+```
+
+**Approach**: The border colors are already set via computed Tailwind classes (`border-red-500`, etc.). Change to use corresponding `bg-*` classes and remove the border properties. May reduce size slightly (18px ring → 12-14px solid dot) for visual proportion.
+
+### D-007: Card Gap Standardization
+
+**Decision**: Standardize `.card-v27` gap from `14px` to `12px` (`gap-3`).
+
+**Rationale**: 14px falls outside the Tailwind 4px spacing scale. Chose 12px (gap-3) over 16px (gap-4) because the card already feels spacious; tightening slightly improves visual density.
+
+## Dependencies
+
+### Technical Dependencies
+- No new library installations required
+- No database changes
+- No API changes
+- Google Fonts CDN (Fraunces, Instrument Sans) — already loaded
+
+### Task Dependencies
+```
+Step 1 (Token updates) ─┬─→ Step 5 (Active row bg)
+                        └─→ All visual steps use updated muted color
+Step 2 (Design system docs) → Independent
+Steps 3-9 → All depend on Step 1, independent of each other
+```
+
+## Risk Register
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|----|------|-----------|--------|------------|
+| R-001 | Typography change breaks visual balance on marketing page | Medium | Low | Visual review of index.vue after change; sans-serif headings may need weight/size adjustments |
+| R-002 | WCAG contrast values render differently across browsers | Low | Medium | Use recommended values with ~0.5:1 headroom; test in Chrome, Firefox, Safari |
+| R-003 | UTabs "link" variant doesn't match desired aesthetic | Low | Low | Can customize via `:ui` prop if default link variant needs tweaking |
+| R-004 | Solid color dots look too heavy for light project colors | Low | Low | Reduce dot size (18px → 12px) and adjust opacity if needed |
+| R-005 | Gallery/dev pages affected by typography change | Low | Very Low | Gallery is a dev tool; update for consistency but not critical |
+| R-006 | JetBrains Mono not loaded (pre-existing) | N/A | Low | Out of scope — falls back to system monospace. Pre-existing issue. |
+
+**No CRITICAL or HIGH risks identified.** All risks are LOW with straightforward mitigations.

--- a/specs/009-dashboard-ui-polish/spec.md
+++ b/specs/009-dashboard-ui-polish/spec.md
@@ -1,0 +1,160 @@
+# Feature Specification: Dashboard UI Polish
+
+**Feature Branch**: `009-dashboard-ui-polish`
+**Created**: 2026-02-24
+**Status**: Draft
+**Input**: User description: "Gemini UI Review (issue #104) — visual hierarchy, typography, color/contrast, and spacing refinements for the dashboard"
+
+## Clarifications
+
+### Session 2026-02-24
+
+- Q: What scope should the serif-to-sans-serif change have? → A: All non-branding text across the app. Serif (Fraunces) reserved only for the LifeStint logo. All headings, titles, and labels switch to sans-serif (Instrument Sans). DESIGN_SYSTEM.md must be updated accordingly.
+- Q: How should the WCAG AA muted text contrast failure be fixed? → A: Make `--text-muted` AA-compliant by adjusting the token values in both light and dark modes to meet 4.5:1 contrast ratio.
+- Q: Should `--bg-active-row` apply to running and paused rows, or running only? → A: Running only. Paused rows keep their current amber treatment. The active row background distinguishes "working now" from "paused."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Clear Visual Hierarchy on Dashboard (Priority: P1)
+
+A user opens the dashboard and can immediately identify which project is actively running a stint. The active project row stands out clearly from inactive projects, and the user's eye is guided naturally from the active project to the timer display without competing visual distractions.
+
+**Why this priority**: The dashboard's primary purpose is to show the user what they're currently working on. If multiple elements compete for attention (segmented control, timer pill, play buttons, active row), the user wastes cognitive effort parsing the screen instead of focusing on their work.
+
+**Independent Test**: Can be tested by viewing the dashboard with one active stint and verifying that a new user can identify the running project within 3 seconds without prior training.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has one project with an active stint, **When** they open the dashboard, **Then** the active project row is visually distinct from all other project rows through a differentiated background or prominent accent indicator.
+2. **Given** a user views the dashboard, **When** they scan the project list, **Then** the Active/Inactive tab control does not visually overpower the project list content beneath it.
+3. **Given** a user has an active stint, **When** they look at the project list row for that project, **Then** the row's visual treatment (background, border, or accent) clearly communicates "this is running" without requiring the user to read button labels.
+
+---
+
+### User Story 2 - Readable and Consistent Typography (Priority: P2)
+
+A user views the dashboard and all text elements use a consistent, readable type system. Timer digits read as a cohesive unit, secondary labels are legible, and font families are used consistently across all UI data components.
+
+**Why this priority**: Inconsistent typography (mixed serif/sans-serif in data displays, overly-spaced timer digits, too-small labels) creates a disjointed experience that undermines perceived quality and can cause readability issues.
+
+**Independent Test**: Can be tested by verifying that all data-display text uses the same font family, timer digits are visually cohesive, and secondary labels meet minimum size requirements.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user views the timer card, **When** they read the project name and timer digits, **Then** all text within the timer card uses a consistent sans-serif font family (serif reserved only for branding/logo).
+2. **Given** a user views the large timer display, **When** they read the elapsed time, **Then** the digits and colons appear as a single cohesive unit without excessive spacing between characters.
+3. **Given** a user views secondary labels (e.g., "Started", "Duration", "Ends"), **When** they read these labels, **Then** the text is legible at normal viewing distance without straining.
+
+---
+
+### User Story 3 - Accessible Color Contrast and Intentional Color Usage (Priority: P2)
+
+A user can comfortably read all text on the dashboard regardless of the color theme. Secondary/muted text meets accessibility contrast requirements, project color indicators are clearly decorative (not interactive-looking), and accent colors are used intentionally to convey meaning.
+
+**Why this priority**: Poor contrast on secondary text creates accessibility barriers. Hollow color rings that look like interactive radio buttons cause confusion. Competing accent colors (green play buttons vs. orange brand color) create visual noise.
+
+**Independent Test**: Can be tested by running a contrast checker on all text/background color combinations and verifying they meet WCAG AA standards, and by confirming project color indicators don't resemble interactive controls.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user views the dashboard in dark mode, **When** they read secondary/muted text (timestamps, stint metadata, inactive icons), **Then** all text meets WCAG AA contrast ratio (minimum 4.5:1 for normal text, 3:1 for large text) against its background.
+2. **Given** a user views the project list, **When** they see the project color indicators, **Then** the indicators appear as solid decorative dots rather than hollow rings that resemble interactive controls.
+3. **Given** a user views multiple interactive elements, **When** they scan the dashboard, **Then** accent colors are used consistently: the brand color for primary actions and active states, with minimal competing color usage for secondary actions.
+
+---
+
+### User Story 4 - Balanced Spacing and Aligned Layout (Priority: P3)
+
+A user views the dashboard and all elements feel properly aligned, evenly spaced, and visually grouped. Navigation items form a cohesive cluster, action buttons within project rows have consistent gaps, and the timer card content is well-proportioned.
+
+**Why this priority**: Spacing inconsistencies are subtle but cumulatively make a UI feel unpolished. Fixing alignment and spacing improves perceived quality and professionalism.
+
+**Independent Test**: Can be tested by verifying consistent gap sizes between action buttons in project rows, proper visual grouping in the header navigation, and proportional spacing within the timer card.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user views a project list row, **When** they look at the action buttons (progress indicator, edit, play/pause), **Then** all buttons have equal spacing between them.
+2. **Given** a user views the header/navigation, **When** they scan the navigation items, **Then** the items appear as a cohesive group rather than loosely floating elements.
+3. **Given** a user views the timer card, **When** they look at the stats section (Started/Duration/Ends) and the large timer below, **Then** the vertical spacing creates a clear visual connection between the stats and the timer rather than excessive separation.
+4. **Given** a user views the stats panel with placeholder/empty values, **When** data is not yet available, **Then** the placeholder values are visually subdued and the layout remains stable (no shifting when real data populates).
+
+---
+
+### Edge Cases
+
+- What happens when project names are very long — does the active row treatment still look correct with text wrapping?
+- How do the visual refinements behave in light mode vs. dark mode? Contrast adjustments must work for both themes.
+- How do the spacing changes affect the dashboard on small screens / narrow viewports?
+- What happens when no stint is active — does the project list still look well-structured without an active row highlight?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The active/inactive tab control MUST use a visually lightweight treatment (e.g., text color change, subtle underline) rather than a heavy filled background that competes with the project list.
+- **FR-002**: The project row with a running stint (not paused) MUST be visually distinguished from all other project rows through a background change, accent border, or elevation treatment. Paused stints retain their existing amber visual treatment and do not receive the active row background.
+- **FR-003**: All text across the application MUST use the sans-serif font family (Instrument Sans); the serif font (Fraunces) MUST be reserved exclusively for the LifeStint logo. This is a system-wide change that requires updating DESIGN_SYSTEM.md typography guidelines.
+- **FR-004**: Timer digits MUST use tabular/monospaced figures and display as a single cohesive unit without excessive character spacing around colons.
+- **FR-005**: All secondary/muted text MUST meet WCAG AA contrast requirements (4.5:1 for normal text, 3:1 for large text) against its background in both light and dark modes. The `--text-muted` token values MUST be adjusted in both modes to achieve compliance (current values fail: dark mode ~3.7:1, light mode ~2.4:1).
+- **FR-006**: Project color indicators MUST be displayed as solid filled dots rather than hollow rings.
+- **FR-007**: Action button spacing within project list rows MUST be consistent and equal across all action items.
+- **FR-008**: The header navigation items MUST be visually grouped as a cohesive navigation cluster.
+- **FR-009**: Secondary labels (e.g., "Started", "Duration", "Ends") MUST be at least 11px equivalent in rendered size for readability.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A new user can identify the currently active project on the dashboard within 3 seconds of first viewing, without prior training or guidance.
+- **SC-002**: 100% of text elements on the dashboard meet WCAG AA contrast ratio requirements in both light and dark modes.
+- **SC-003**: No user confuses a project color indicator with an interactive control (validated via visual inspection — indicators are clearly decorative).
+- **SC-004**: The application typography uses exactly 3 font families with clear roles: serif (Fraunces) exclusively for the LifeStint logo, sans-serif (Instrument Sans) for all UI text and headings, and monospace (JetBrains Mono) for timer digits and numerical displays.
+- **SC-005**: Action button gaps within project list rows are uniform to within 1px tolerance across all project cards.
+- **SC-006**: The dashboard visual refinements render correctly across viewport widths from 768px (tablet) to 1920px (desktop).
+
+## Design System Alignment
+
+This section maps each functional requirement to existing design tokens in `app/assets/css/tokens.css` and identifies gaps requiring new tokens or value adjustments.
+
+### Token Changes Required
+
+**Value adjustment — `--text-muted` (both modes)**:
+The current muted text color fails WCAG AA in both modes: dark mode (`#78716c` on `#1c1917`) yields ~3.7:1, and light mode (`#a8a29e` on `#fffbf5`) yields ~2.4:1. Both values MUST be adjusted to achieve at minimum 4.5:1 contrast ratio. Applies to FR-005.
+
+**New token — `--bg-active-row`**:
+No existing token provides a semantically distinct background for the "currently running stint" project row. A new token is needed to represent the subtle background elevation or accent-tinted fill for active rows, with appropriate light and dark mode values. Applies to FR-002.
+
+### Existing Token Mapping
+
+| Requirement | Relevant Tokens | Status |
+|-------------|----------------|--------|
+| FR-001 (Tab control weight) | `--accent-primary` for active tab indicator | Existing token, usage change |
+| FR-002 (Active row distinction) | **`--bg-active-row`** (new) | New token needed; applies to running stints only (not paused) |
+| FR-003 (Typography consistency) | `--font-sans`, `--font-serif` | System-wide change: all headings/titles switch from `--font-serif` to `--font-sans`. Serif used only for logo. Requires DESIGN_SYSTEM.md update |
+| FR-004 (Timer digit cohesion) | `--font-mono` (JetBrains Mono) | Existing token, CSS adjustment: remove positive `letter-spacing` and apply `tabular-nums` |
+| FR-005 (Muted text contrast) | `--text-muted` | Existing token, **value change in both light and dark modes** |
+| FR-006 (Solid color dots) | Project color classes (Tailwind) | No token change, CSS change from border-only to background-fill |
+| FR-007 (Button spacing) | Tailwind spacing scale (`gap-2`, `gap-3`) | No new token, standardize non-standard `14px` gap to nearest scale value |
+| FR-008 (Navigation grouping) | `--bg-secondary` | Already correctly used in navigation container |
+| FR-009 (Label minimum size) | No size token (uses raw px) | CSS adjustment: raise `.meta-label` mobile from 10px to 11px minimum |
+
+### Non-Standard Values to Standardize
+
+The project list card (`.card-v27`) currently uses `gap: 14px`, which falls outside the Tailwind 4px spacing scale. This SHOULD be standardized to either `12px` (`gap-3`) or `16px` (`gap-4`) for consistency with the design system.
+
+## Assumptions
+
+- The current dark mode design is the primary mode being reviewed; light mode should receive equivalent adjustments but dark mode is the design reference.
+- The project color palette (blue, red, green, yellow, gray assigned to projects) remains unchanged — only the shape of the color indicator changes (hollow ring → solid dot).
+- The existing component structure (ProjectListCard, DashboardTimerHero, DashboardSidebar, default layout) remains intact — this is a visual refinement, not a structural refactoring.
+- Timer card pause/stop controls remain the primary control surface; project list row controls are secondary.
+- No new functionality is being added — this is purely a visual polish pass.
+- The serif-to-sans-serif typography change is system-wide: `docs/DESIGN_SYSTEM.md` must be updated to reflect the new typography rules (serif for logo only, sans-serif for all UI text).
+
+## Out of Scope
+
+- Mobile-first responsive redesign (this focuses on tablet+ viewports)
+- New features, interactions, or functionality
+- Changes to the color mode toggle or overall theme system
+- Animation or transition changes
+- Restructuring of the component hierarchy

--- a/specs/009-dashboard-ui-polish/tasks.md
+++ b/specs/009-dashboard-ui-polish/tasks.md
@@ -29,7 +29,7 @@
 
 **⚠️ CRITICAL**: US1's active row background (T003) depends on the `--bg-active-row` token defined here. US3's contrast compliance depends on the `--text-muted` values set here.
 
-- [ ] T001 Update `--text-muted` token values (light: `#a8a29e` → `#736b66`, dark: `#78716c` → `#908984`) and add new `--bg-active-row` token (light: `rgba(22, 163, 74, 0.05)`, dark: `rgba(34, 197, 94, 0.08)`) in `app/assets/css/tokens.css`
+- [x] T001 Update `--text-muted` token values (light: `#a8a29e` → `#736b66`, dark: `#78716c` → `#908984`) and add new `--bg-active-row` token (light: `rgba(22, 163, 74, 0.05)`, dark: `rgba(34, 197, 94, 0.08)`) in `app/assets/css/tokens.css`
 
 **Checkpoint**: Token foundation ready — all user stories can now proceed
 
@@ -45,8 +45,8 @@
 
 ### Implementation for User Story 1
 
-- [ ] T002 [P] [US1] Switch `UTabs` to `variant="link"` `color="neutral"` and remove `font-serif` class from "Your Projects" section heading in `app/pages/dashboard.vue`
-- [ ] T003 [P] [US1] Add `background: var(--bg-active-row)` to `.card-v27.state-running` CSS rule in `app/components/ProjectListCard.vue`
+- [x] T002 [P] [US1] Switch `UTabs` to `variant="link"` `color="neutral"` and remove `font-serif` class from "Your Projects" section heading in `app/pages/dashboard.vue`
+- [x] T003 [P] [US1] Add `background: var(--bg-active-row)` to `.card-v27.state-running` CSS rule in `app/components/ProjectListCard.vue`
 
 **Checkpoint**: Dashboard visual hierarchy established — active project stands out, tabs are lightweight
 
@@ -62,12 +62,12 @@
 
 ### Implementation for User Story 2
 
-- [ ] T004 [P] [US2] Remove `font-serif` from `.session-project`, remove `letter-spacing: 0.02em` from `.timer-display`, add `font-variant-numeric: tabular-nums` to `.timer-display`, and raise `.meta-label` font-size from `10px` to `11px` in `app/components/DashboardTimerHero.vue`
-- [ ] T005 [P] [US2] Remove `font-serif` from empty state headings in `app/components/ProjectList.vue` (~3 instances) and `app/components/ArchivedProjectsList.vue` (~1 instance)
-- [ ] T006 [P] [US2] Remove `font-serif` from page headings in `app/pages/auth/login.vue`, `app/pages/auth/register.vue`, `app/pages/auth/callback.vue` (~3 headings), `app/pages/auth/verify-email.vue`, `app/pages/auth/forgot-password.vue`, `app/pages/auth/reset-password.vue`
-- [ ] T007 [P] [US2] Remove `font-serif` from headings in `app/pages/index.vue` (~7 instances — hero, sections, CTA, pricing, FAQ) and page titles in `app/pages/legal/terms.vue`, `app/pages/legal/privacy.vue`
-- [ ] T008 [P] [US2] Remove `font-serif` from section headings in `app/pages/gallery.vue` (~5 instances) and layout title in `app/layouts/component-gallery.vue`
-- [ ] T009 [P] [US2] Update `docs/DESIGN_SYSTEM.md`: (a) change typography rules to reserve Fraunces exclusively for the LifeStint logo wordmark, Instrument Sans for all headings/titles/labels/body text, JetBrains Mono for timer digits — update Font Families table, Typography Patterns, Cards example, Empty States example, Typography Summary, Accessibility examples, and Best Practices sections; (b) update `--text-muted` hex values from `#a8a29e`/`#78716c` to `#736b66`/`#908984` in Token Reference, Color System table, and Quick Reference; (c) verify card spacing convention (12px gap) is consistent with Spacing Scale documentation
+- [x] T004 [P] [US2] Remove `font-serif` from `.session-project`, remove `letter-spacing: 0.02em` from `.timer-display`, add `font-variant-numeric: tabular-nums` to `.timer-display`, and raise `.meta-label` font-size from `10px` to `11px` in `app/components/DashboardTimerHero.vue`
+- [x] T005 [P] [US2] Remove `font-serif` from empty state headings in `app/components/ProjectList.vue` (~3 instances) and `app/components/ArchivedProjectsList.vue` (~1 instance)
+- [x] T006 [P] [US2] Remove `font-serif` from page headings in `app/pages/auth/login.vue`, `app/pages/auth/register.vue`, `app/pages/auth/callback.vue` (~3 headings), `app/pages/auth/verify-email.vue`, `app/pages/auth/forgot-password.vue`, `app/pages/auth/reset-password.vue`
+- [x] T007 [P] [US2] Remove `font-serif` from headings in `app/pages/index.vue` (~7 instances — hero, sections, CTA, pricing, FAQ) and page titles in `app/pages/legal/terms.vue`, `app/pages/legal/privacy.vue`
+- [x] T008 [P] [US2] Remove `font-serif` from section headings in `app/pages/gallery.vue` (~5 instances) and layout title in `app/layouts/component-gallery.vue`
+- [x] T009 [P] [US2] Update `docs/DESIGN_SYSTEM.md`: (a) change typography rules to reserve Fraunces exclusively for the LifeStint logo wordmark, Instrument Sans for all headings/titles/labels/body text, JetBrains Mono for timer digits — update Font Families table, Typography Patterns, Cards example, Empty States example, Typography Summary, Accessibility examples, and Best Practices sections; (b) update `--text-muted` hex values from `#a8a29e`/`#78716c` to `#736b66`/`#908984` in Token Reference, Color System table, and Quick Reference; (c) verify card spacing convention (12px gap) is consistent with Spacing Scale documentation
 
 **Checkpoint**: Typography system is consistent — serif appears only on logos, timer is cohesive, labels are readable
 
@@ -83,7 +83,7 @@
 
 ### Implementation for User Story 3
 
-- [ ] T010 [US3] Change project color indicators from hollow rings to solid filled dots in `app/components/ProjectListCard.vue` — update `.project-color` CSS (remove `background: transparent`, `border-width`, `border-style`; set `width: 12px`, `height: 12px`; add background fill) and update computed color classes from `border-*` to `bg-*` variants in the template
+- [x] T010 [US3] Change project color indicators from hollow rings to solid filled dots in `app/components/ProjectListCard.vue` — update `.project-color` CSS (remove `background: transparent`, `border-width`, `border-style`; set `width: 12px`, `height: 12px`; add background fill) and update computed color classes from `border-*` to `bg-*` variants in the template
 
 **Checkpoint**: Color usage is accessible and intentional — muted text passes WCAG AA, dots are clearly decorative
 
@@ -99,8 +99,8 @@
 
 ### Implementation for User Story 4
 
-- [ ] T011 [US4] Standardize `.card-v27` gap from `14px` to `12px` and padding from `14px 20px` to `12px 20px` in `app/components/ProjectListCard.vue`
-- [ ] T012 [P] [US4] Verify navigation grouping in `app/layouts/default.vue` — confirm existing `bg-[#fef7ed] dark:bg-[#1f1b18] p-1 rounded-full gap-1` container satisfies FR-008 (likely no-op; document finding)
+- [x] T011 [US4] Standardize `.card-v27` gap from `14px` to `12px` and padding from `14px 20px` to `12px 20px` in `app/components/ProjectListCard.vue`
+- [x] T012 [P] [US4] Verify navigation grouping in `app/layouts/default.vue` — confirm existing `bg-[#fef7ed] dark:bg-[#1f1b18] p-1 rounded-full gap-1` container satisfies FR-008 (likely no-op; document finding)
 
 **Checkpoint**: All spacing is consistent and aligned — card gaps follow design system scale, navigation is cohesive
 
@@ -110,9 +110,9 @@
 
 **Purpose**: Final verification across all stories, regression testing, cross-mode validation
 
-- [ ] T013 Verify `font-serif` removal completeness — run `grep -r "font-serif" app/` and confirm only 9 logo instances remain (per research.md inventory)
-- [ ] T014 Run `npm run lint:fix && npm run type-check && npm run test:run` to verify no regressions
-- [ ] T015 Visual review of all modified pages in both light and dark modes across viewports (768px, 1024px, 1440px, 1920px) — verify SC-001 through SC-006
+- [x] T013 Verify `font-serif` removal completeness — run `grep -r "font-serif" app/` and confirm only 9 logo instances remain (per research.md inventory)
+- [x] T014 Run `npm run lint:fix && npm run type-check && npm run test:run` to verify no regressions
+- [ ] T015 *(requires manual visual inspection)* Visual review of all modified pages in both light and dark modes across viewports (768px, 1024px, 1440px, 1920px) — verify SC-001 through SC-006
 
 ---
 

--- a/specs/009-dashboard-ui-polish/tasks.md
+++ b/specs/009-dashboard-ui-polish/tasks.md
@@ -1,0 +1,216 @@
+# Tasks: Dashboard UI Polish
+
+**Input**: Design documents from `/specs/009-dashboard-ui-polish/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Not requested — this is a visual-only feature. Verification is through lint, type-check, existing test regression, and visual inspection per SC-001 through SC-006.
+
+**Organization**: Tasks grouped by user story (P1 → P2 → P3) from spec.md. Each story can be validated independently through visual inspection.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+- Exact file paths included in all task descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No setup needed — branch `009-dashboard-ui-polish` exists, no new dependencies required, no database changes. All changes modify existing files.
+
+*(No tasks in this phase)*
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Token value changes that provide the color foundation consumed by US1 (active row background) and US3 (muted text contrast). These MUST be complete before story implementation.
+
+**⚠️ CRITICAL**: US1's active row background (T003) depends on the `--bg-active-row` token defined here. US3's contrast compliance depends on the `--text-muted` values set here.
+
+- [ ] T001 Update `--text-muted` token values (light: `#a8a29e` → `#736b66`, dark: `#78716c` → `#908984`) and add new `--bg-active-row` token (light: `rgba(22, 163, 74, 0.05)`, dark: `rgba(34, 197, 94, 0.08)`) in `app/assets/css/tokens.css`
+
+**Checkpoint**: Token foundation ready — all user stories can now proceed
+
+---
+
+## Phase 3: User Story 1 — Clear Visual Hierarchy on Dashboard (Priority: P1) 🎯 MVP
+
+**Goal**: The active project is instantly identifiable. The tab control is visually lightweight and doesn't compete with project list content.
+
+**Independent Test**: Open dashboard with one running stint → user can identify the active project within 3 seconds without prior training. Tab control feels secondary to the project list.
+
+**Requirements covered**: FR-001 (tab control weight), FR-002 (active row distinction)
+
+### Implementation for User Story 1
+
+- [ ] T002 [P] [US1] Switch `UTabs` to `variant="link"` `color="neutral"` and remove `font-serif` class from "Your Projects" section heading in `app/pages/dashboard.vue`
+- [ ] T003 [P] [US1] Add `background: var(--bg-active-row)` to `.card-v27.state-running` CSS rule in `app/components/ProjectListCard.vue`
+
+**Checkpoint**: Dashboard visual hierarchy established — active project stands out, tabs are lightweight
+
+---
+
+## Phase 4: User Story 2 — Readable and Consistent Typography (Priority: P2)
+
+**Goal**: All UI text uses Instrument Sans (sans-serif). Serif (Fraunces) reserved exclusively for the LifeStint logo. Timer digits are cohesive. Labels meet minimum readability size.
+
+**Independent Test**: Grep `font-serif` in `app/` — only 9 logo instances remain. Timer colons sit close to digits. "Started"/"Duration"/"Ends" labels render at ≥11px.
+
+**Requirements covered**: FR-003 (typography consistency), FR-004 (timer digit cohesion), FR-009 (label minimum size)
+
+### Implementation for User Story 2
+
+- [ ] T004 [P] [US2] Remove `font-serif` from `.session-project`, remove `letter-spacing: 0.02em` from `.timer-display`, add `font-variant-numeric: tabular-nums` to `.timer-display`, and raise `.meta-label` font-size from `10px` to `11px` in `app/components/DashboardTimerHero.vue`
+- [ ] T005 [P] [US2] Remove `font-serif` from empty state headings in `app/components/ProjectList.vue` (~3 instances) and `app/components/ArchivedProjectsList.vue` (~1 instance)
+- [ ] T006 [P] [US2] Remove `font-serif` from page headings in `app/pages/auth/login.vue`, `app/pages/auth/register.vue`, `app/pages/auth/callback.vue` (~3 headings), `app/pages/auth/verify-email.vue`, `app/pages/auth/forgot-password.vue`, `app/pages/auth/reset-password.vue`
+- [ ] T007 [P] [US2] Remove `font-serif` from headings in `app/pages/index.vue` (~7 instances — hero, sections, CTA, pricing, FAQ) and page titles in `app/pages/legal/terms.vue`, `app/pages/legal/privacy.vue`
+- [ ] T008 [P] [US2] Remove `font-serif` from section headings in `app/pages/gallery.vue` (~5 instances) and layout title in `app/layouts/component-gallery.vue`
+- [ ] T009 [P] [US2] Update `docs/DESIGN_SYSTEM.md`: (a) change typography rules to reserve Fraunces exclusively for the LifeStint logo wordmark, Instrument Sans for all headings/titles/labels/body text, JetBrains Mono for timer digits — update Font Families table, Typography Patterns, Cards example, Empty States example, Typography Summary, Accessibility examples, and Best Practices sections; (b) update `--text-muted` hex values from `#a8a29e`/`#78716c` to `#736b66`/`#908984` in Token Reference, Color System table, and Quick Reference; (c) verify card spacing convention (12px gap) is consistent with Spacing Scale documentation
+
+**Checkpoint**: Typography system is consistent — serif appears only on logos, timer is cohesive, labels are readable
+
+---
+
+## Phase 5: User Story 3 — Accessible Color Contrast and Intentional Color Usage (Priority: P2)
+
+**Goal**: All muted text meets WCAG AA contrast (4.5:1). Project color indicators are clearly decorative solid dots, not interactive-looking hollow rings.
+
+**Independent Test**: Browser contrast checker shows ≥4.5:1 for `--text-muted` against all background tokens in both modes. Color dots look solid and decorative, not like radio buttons.
+
+**Requirements covered**: FR-005 (muted text contrast — achieved via T001 token change), FR-006 (solid color dots)
+
+### Implementation for User Story 3
+
+- [ ] T010 [US3] Change project color indicators from hollow rings to solid filled dots in `app/components/ProjectListCard.vue` — update `.project-color` CSS (remove `background: transparent`, `border-width`, `border-style`; set `width: 12px`, `height: 12px`; add background fill) and update computed color classes from `border-*` to `bg-*` variants in the template
+
+**Checkpoint**: Color usage is accessible and intentional — muted text passes WCAG AA, dots are clearly decorative
+
+---
+
+## Phase 6: User Story 4 — Balanced Spacing and Aligned Layout (Priority: P3)
+
+**Goal**: Card spacing follows the Tailwind 4px scale. Action buttons have uniform gaps. Navigation items form a cohesive group.
+
+**Independent Test**: DevTools measurement shows card gap is `12px` (not `14px`). Action button gaps are equal across all project rows. Navigation items appear grouped.
+
+**Requirements covered**: FR-007 (button spacing), FR-008 (navigation grouping)
+
+### Implementation for User Story 4
+
+- [ ] T011 [US4] Standardize `.card-v27` gap from `14px` to `12px` and padding from `14px 20px` to `12px 20px` in `app/components/ProjectListCard.vue`
+- [ ] T012 [P] [US4] Verify navigation grouping in `app/layouts/default.vue` — confirm existing `bg-[#fef7ed] dark:bg-[#1f1b18] p-1 rounded-full gap-1` container satisfies FR-008 (likely no-op; document finding)
+
+**Checkpoint**: All spacing is consistent and aligned — card gaps follow design system scale, navigation is cohesive
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification across all stories, regression testing, cross-mode validation
+
+- [ ] T013 Verify `font-serif` removal completeness — run `grep -r "font-serif" app/` and confirm only 9 logo instances remain (per research.md inventory)
+- [ ] T014 Run `npm run lint:fix && npm run type-check && npm run test:run` to verify no regressions
+- [ ] T015 Visual review of all modified pages in both light and dark modes across viewports (768px, 1024px, 1440px, 1920px) — verify SC-001 through SC-006
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: N/A — no setup required
+- **Foundational (Phase 2)**: No dependencies — start immediately. **BLOCKS** US1 (T003 needs `--bg-active-row` token)
+- **US1 (Phase 3)**: Depends on Phase 2 completion (T003 uses `--bg-active-row`)
+- **US2 (Phase 4)**: Depends on Phase 2 completion (muted text renders with updated values)
+- **US3 (Phase 5)**: Depends on Phase 2 completion (contrast already fixed by T001)
+- **US4 (Phase 6)**: Depends on Phase 2 completion (no direct token dependency, but phases should be sequential for `ProjectListCard.vue` file contention with T003 and T010)
+- **Polish (Phase 7)**: Depends on all story phases being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: After Phase 2 — no dependencies on other stories
+- **US2 (P2)**: After Phase 2 — no dependencies on other stories. Can run in parallel with US1
+- **US3 (P2)**: After Phase 2 — no dependencies on other stories. **File contention**: T010 touches `ProjectListCard.vue` (also modified by T003 in US1 and T011 in US4) → execute US3 after US1 or manage edits carefully
+- **US4 (P3)**: After Phase 2 — **file contention**: T011 touches `ProjectListCard.vue` → execute after US1 and US3
+
+### File Contention Map
+
+`ProjectListCard.vue` is modified by 3 tasks across 3 different stories:
+1. T003 [US1] — adds `background: var(--bg-active-row)` to `.state-running`
+2. T010 [US3] — changes `.project-color` from hollow ring to solid dot
+3. T011 [US4] — standardizes `.card-v27` gap and padding
+
+**Recommended order**: T003 → T010 → T011 (matches phase/priority ordering)
+
+### Parallel Opportunities
+
+**Within Phase 3 (US1)**:
+- T002 and T003 are [P] — different files (`dashboard.vue` vs `ProjectListCard.vue`)
+
+**Within Phase 4 (US2)** — maximum parallelism:
+- T004, T005, T006, T007, T008, T009 are ALL [P] — each touches different files
+
+**Within Phase 6 (US4)**:
+- T011 and T012 are [P] — different files (`ProjectListCard.vue` vs `default.vue`)
+
+**Cross-story parallelism**:
+- US1 and US2 phases can run in parallel (no shared files, both depend only on Phase 2)
+- US3 must wait for US1 due to `ProjectListCard.vue` contention
+- US4 must wait for US3 due to `ProjectListCard.vue` contention
+
+---
+
+## Parallel Example: User Story 2
+
+```text
+# All 6 tasks can launch simultaneously (different files, no dependencies):
+T004: DashboardTimerHero.vue (font-serif + timer + label)
+T005: ProjectList.vue + ArchivedProjectsList.vue (font-serif)
+T006: auth/*.vue × 6 files (font-serif)
+T007: index.vue + legal/*.vue (font-serif)
+T008: gallery.vue + component-gallery.vue (font-serif)
+T009: DESIGN_SYSTEM.md (docs update)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 2: Foundational (T001 — token updates)
+2. Complete Phase 3: US1 (T002, T003 — tabs + active row)
+3. **STOP and VALIDATE**: Dashboard hierarchy is clear, tabs are lightweight, active row is distinct
+4. This delivers the highest-priority visual improvement with just 3 tasks
+
+### Recommended: Atomic Delivery
+
+Per plan.md, all 9 requirements work together for a cohesive visual improvement. Deliver as a single PR:
+
+1. Phase 2: Foundation (T001) → 1 task
+2. Phase 3: US1 (T002–T003) → 2 tasks
+3. Phase 4: US2 (T004–T009) → 6 tasks (all parallel)
+4. Phase 5: US3 (T010) → 1 task
+5. Phase 6: US4 (T011–T012) → 2 tasks
+6. Phase 7: Polish (T013–T015) → 3 tasks
+7. Total: 15 tasks, single PR
+
+### Natural Slices (if incremental preferred)
+
+1. **Slice 1**: T001 + T009 (tokens + docs) — foundation, no visual regressions
+2. **Slice 2**: T002–T008 + T010 (hierarchy + typography + dots) — P1 + P2 requirements
+3. **Slice 3**: T011–T012 (spacing) — P3 requirements
+4. **Slice 4**: T013–T015 (polish) — verification and regression
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks within the same phase
+- No test tasks generated — spec confirms visual inspection as primary verification method
+- `ProjectListCard.vue` is the highest-contention file (3 tasks across 3 stories) — phase ordering prevents conflicts
+- T012 (navigation grouping) is likely a no-op — existing implementation already satisfies FR-008 per quickstart.md analysis
+- Font-serif removal (T004–T008) is the highest-volume work (~30 class removals across ~15 files) but is entirely parallelizable
+- All token values in T001 are from research.md decision D-001 and D-002 with WCAG AA headroom built in


### PR DESCRIPTION
## Summary

- **Visual hierarchy**: Active (running) project gets a subtle green-tinted background via new `--bg-active-row` token; tab control switched to lightweight `link` variant
- **Typography consistency**: Reserved `font-serif` (Fraunces) exclusively for the LifeStint logo wordmark — removed from ~30 headings across 15 files; added `tabular-nums` to timer display; raised meta-label minimum to 11px
- **Accessibility**: Upgraded `--text-muted` tokens from ~2.4:1 to ~5.0:1 contrast ratio (WCAG AA compliant); replaced hollow color rings with solid 12px dots that read as decorative, not interactive
- **Spacing**: Standardized card gap/padding from 14px to 12px to align with Tailwind's 4px scale

Implements spec `009-dashboard-ui-polish` (9 functional requirements across 4 user stories).

## Changes

| Area | Files | What changed |
|------|-------|-------------|
| Tokens | `tokens.css` | `--text-muted` contrast fix, new `--bg-active-row` |
| Dashboard | `dashboard.vue` | UTabs → `variant="link" color="neutral"`, heading sans-serif |
| Project cards | `ProjectListCard.vue` | Active row bg, solid color dots, 12px gap/padding |
| Timer | `DashboardTimerHero.vue` | Sans-serif heading, `tabular-nums`, 11px labels |
| Typography | 12 page/component files | `font-serif` removed from non-logo headings |
| Docs | `DESIGN_SYSTEM.md` | Updated typography rules, token values, spacing docs |

## Test plan

- [x] `npm run lint:fix` — passes
- [x] `npm run type-check` — passes  
- [x] `npm run test:run` — unit tests pass (integration tests require local Supabase)
- [ ] Visual review: light + dark mode across 768px / 1024px / 1440px / 1920px viewports
- [ ] Verify only 9 `font-serif` instances remain (all logo wordmarks)
- [ ] Verify `--text-muted` contrast ≥ 4.5:1 in both modes via browser DevTools
- [ ] Verify color dots appear solid/decorative, not like radio buttons